### PR TITLE
Spring bank holiday is last Monday of the month, but it wasn't calculate...

### DIFF
--- a/src/PublicHoliday/HolidayCalculator.cs
+++ b/src/PublicHoliday/HolidayCalculator.cs
@@ -48,6 +48,14 @@ namespace PublicHoliday
             return hol;
         }
 
+        public static DateTime FindPrevious(DateTime hol, DayOfWeek day)
+        {
+            while (hol.DayOfWeek != day)
+                hol = hol.AddDays(-1);
+
+            return hol;
+        }
+
         /// <summary>
         /// Returns the next working day (Mon-Fri, not public holiday)
         /// after the specified date (or the same date)

--- a/src/PublicHoliday/UKBankHoliday.cs
+++ b/src/PublicHoliday/UKBankHoliday.cs
@@ -83,8 +83,8 @@ namespace PublicHoliday
         {
             if (year == 2002) return new DateTime(2002, 6, 4); //Golden Jubilee of Elizabeth II
             if (year == 2012) return new DateTime(2012, 6, 4); //Queen's Diamond Jubilee
-            DateTime hol = new DateTime(year, 5, 24);
-            hol = HolidayCalculator.FindFirstMonday(hol);
+            DateTime hol = new DateTime(year, 5, 31);
+            hol = HolidayCalculator.FindPrevious(hol, DayOfWeek.Monday);
             return hol;
         }
 

--- a/tests/PublicHolidayTests/TestUKBankHoliday.cs
+++ b/tests/PublicHolidayTests/TestUKBankHoliday.cs
@@ -219,5 +219,13 @@ namespace PublicHolidayTests
             var dt = UKBankHoliday.BoxingDay(2015);
             Assert.AreEqual(28, dt.Day);
         }
+
+        [TestMethod]
+        public void TestSpringLastDayOfMonthIsAMonday()
+        {
+            var dt = UKBankHoliday.Spring(2021);
+            var expected = new DateTime(2021, 5, 31);
+            Assert.AreEqual(dt, expected);
+        }
     }
 }


### PR DESCRIPTION
This pull request fixes a bug that occurs if the last day of May is a Monday.

Currently, the spring bank holiday is calculated as the 24th May instead of the 31st.  

2021 is an example of a year where this occurs.

Hope this helps!