### PR TITLE
Add previous working day method

### DIFF
--- a/src/PublicHoliday/BelgiumPublicHoliday.cs
+++ b/src/PublicHoliday/BelgiumPublicHoliday.cs
@@ -229,6 +229,17 @@ namespace PublicHoliday
             return HolidayCalculator.NextWorkingDay(this, dt);
         }
 
+        /// <summary>
+        /// Returns the previous working day (Mon-Fri, not public holiday)
+        /// before the specified date (or the same date)
+        /// </summary>
+        /// <param name="dt">The date you wish to check</param>
+        /// <returns>A date that is a working day</returns>
+        public DateTime PreviousWorkingDay(DateTime dt)
+        {
+            return HolidayCalculator.PreviousWorkingDay(this, dt);
+        }
+
 
         /// <summary>
         /// Check if a specific date is a public holiday.

--- a/src/PublicHoliday/CanadaPublicHoliday.cs
+++ b/src/PublicHoliday/CanadaPublicHoliday.cs
@@ -230,6 +230,17 @@ namespace PublicHoliday
         }
 
         /// <summary>
+        /// Returns the previous working day (Mon-Fri, not public holiday)
+        /// before the specified date (or the same date)
+        /// </summary>
+        /// <param name="dt">The date you wish to check</param>
+        /// <returns>A date that is a working day</returns>
+        public DateTime PreviousWorkingDay(DateTime dt)
+        {
+            return HolidayCalculator.PreviousWorkingDay(this, dt);
+        }
+
+        /// <summary>
         /// Check if a specific date is a public holiday.
         /// </summary>
         /// <param name="dt">The date you wish to check</param>

--- a/src/PublicHoliday/DutchPublicHoliday.cs
+++ b/src/PublicHoliday/DutchPublicHoliday.cs
@@ -178,6 +178,17 @@ namespace PublicHoliday
             return HolidayCalculator.NextWorkingDay(this, dt);
         }
 
+        /// <summary>
+        /// Returns the previous working day (Mon-Fri, not public holiday)
+        /// before the specified date (or the same date)
+        /// </summary>
+        /// <param name="dt">The date you wish to check</param>
+        /// <returns>A date that is a working day</returns>
+        public DateTime PreviousWorkingDay(DateTime dt)
+        {
+            return HolidayCalculator.PreviousWorkingDay(this, dt);
+        }
+
 
         /// <summary>
         /// Check if a specific date is a public holiday.

--- a/src/PublicHoliday/FrancePublicHoliday.cs
+++ b/src/PublicHoliday/FrancePublicHoliday.cs
@@ -212,6 +212,17 @@ namespace PublicHoliday
         }
 
         /// <summary>
+        /// Returns the previous working day (Mon-Fri, not public holiday)
+        /// before the specified date (or the same date)
+        /// </summary>
+        /// <param name="dt">The date you wish to check</param>
+        /// <returns>A date that is a working day</returns>
+        public DateTime PreviousWorkingDay(DateTime dt)
+        {
+            return HolidayCalculator.PreviousWorkingDay(this, dt);
+        }
+
+        /// <summary>
         /// Check if a specific date is a public holiday.
         /// Obviously the PublicHoliday list is more efficient for repeated checks
         /// Note holidays can fall on weekends and there is no fixed moving of such dates.

--- a/src/PublicHoliday/HolidayCalculator.cs
+++ b/src/PublicHoliday/HolidayCalculator.cs
@@ -95,5 +95,42 @@ namespace PublicHoliday
             }
             return dt;
         }
+
+        /// <summary>
+        /// Returns the previous working day (Mon-Fri, not public holiday)
+        /// before the specified date (or the same date)
+        /// </summary>
+        /// <param name="holidayCalendar">The holiday calendar.</param>
+        /// <param name="dt">The date you wish to check</param>
+        /// <returns>
+        /// A date that is a working day
+        /// </returns>
+        public static DateTime PreviousWorkingDay(IPublicHolidays holidayCalendar, DateTime dt)
+        {
+            bool isWorkingDay = false;
+
+            //loops through
+            while (isWorkingDay == false)
+            {
+                //Mon-Fri and not bank holiday, it's okay
+                if (dt.DayOfWeek != DayOfWeek.Saturday &&
+                    dt.DayOfWeek != DayOfWeek.Sunday &&
+                    !holidayCalendar.IsPublicHoliday(dt))
+                    isWorkingDay = true;
+                //it's Sunday, so skip to Friday
+                else if (dt.DayOfWeek == DayOfWeek.Sunday)
+                    dt = dt.AddDays(-2);
+                //it's Saturday, so skip to Friday
+                else if (dt.DayOfWeek == DayOfWeek.Saturday)
+                    dt = dt.AddDays(-1);
+                //it's Monday (bank holiday), so skip to Friday
+                else if (dt.DayOfWeek == DayOfWeek.Monday)
+                    dt = dt.AddDays(-3);
+                //it's Thi-Fr (bank holiday), so previous day
+                else
+                    dt = dt.AddDays(-1);
+            }
+            return dt;
+        }
     }
 }

--- a/src/PublicHoliday/IPublicHolidays.cs
+++ b/src/PublicHoliday/IPublicHolidays.cs
@@ -31,6 +31,14 @@ namespace PublicHoliday
         DateTime NextWorkingDay(DateTime dt);
 
         /// <summary>
+        /// Returns the previous working day (Mon-Fri, not public holiday)
+        /// before the specified date (or the same date)
+        /// </summary>
+        /// <param name="dt">The date you wish to check</param>
+        /// <returns>A date that is a working day</returns>
+        DateTime PreviousWorkingDay(DateTime dt);
+
+        /// <summary>
         /// Check if a specific date is a public holiday.
         /// Obviously the <see cref="PublicHolidays"/> list is more efficient for repeated checks
         /// </summary>

--- a/src/PublicHoliday/NorwayPublicHoliday.cs
+++ b/src/PublicHoliday/NorwayPublicHoliday.cs
@@ -222,6 +222,16 @@ namespace PublicHoliday
             return HolidayCalculator.NextWorkingDay(this, dt);
         }
 
+        /// <summary>
+        /// Returns the previous working day (Mon-Fri, not public holiday)
+        /// before the specified date (or the same date)
+        /// </summary>
+        /// <param name="dt">The date you wish to check</param>
+        /// <returns>A date that is a working day</returns>
+        public DateTime PreviousWorkingDay(DateTime dt)
+        {
+            return HolidayCalculator.PreviousWorkingDay(this, dt);
+        }
 
         /// <summary>
         /// Check if a specific date is a public holiday.

--- a/src/PublicHoliday/UKBankHoliday.cs
+++ b/src/PublicHoliday/UKBankHoliday.cs
@@ -226,6 +226,17 @@ namespace PublicHoliday
         }
 
         /// <summary>
+        /// Returns the previous working day (Mon-Fri, not public holiday)
+        /// before the specified date (or the same date)
+        /// </summary>
+        /// <param name="dt">The date you wish to check</param>
+        /// <returns>A date that is a working day</returns>
+        public DateTime PreviousWorkingDay(DateTime dt)
+        {
+            return HolidayCalculator.PreviousWorkingDay(this, dt);
+        }
+
+        /// <summary>
         /// Check if a specific date is a public holiday.
         /// </summary>
         /// <param name="dt">The date you wish to check</param>

--- a/src/PublicHoliday/USAPublicHoliday.cs
+++ b/src/PublicHoliday/USAPublicHoliday.cs
@@ -246,5 +246,16 @@ namespace PublicHoliday
         {
             return HolidayCalculator.NextWorkingDay(this, dt);
         }
+
+        /// <summary>
+        /// Returns the previous working day (Mon-Fri, not public holiday)
+        /// before the specified date (or the same date)
+        /// </summary>
+        /// <param name="dt">The date you wish to check</param>
+        /// <returns>A date that is a working day</returns>
+        public DateTime PreviousWorkingDay(DateTime dt)
+        {
+            return HolidayCalculator.PreviousWorkingDay(this, dt);
+        }
     }
 }

--- a/tests/PublicHolidayTests/TestNorwayPublicHoliday.cs
+++ b/tests/PublicHolidayTests/TestNorwayPublicHoliday.cs
@@ -35,8 +35,15 @@ namespace PublicHolidayTests
         [TestMethod]
         public void TestNextWorkingDay()
         {
-            var result = new NorwayPublicHoliday().NextWorkingDay(new DateTime(2006, 05, 25));
-            Assert.AreEqual(new DateTime(2006, 05, 26), result);
+            var result = new NorwayPublicHoliday().NextWorkingDay(new DateTime(2015, 4, 2)); //Maundy thursday
+            Assert.AreEqual(new DateTime(2015, 4, 7), result); //Day after easter monday
+        }
+
+        [TestMethod]
+        public void TestPreviousWorkingDay()
+        {
+            var result = new NorwayPublicHoliday().PreviousWorkingDay(new DateTime(2015, 4, 6)); //Easter monday
+            Assert.AreEqual(new DateTime(2015, 4, 1), result); //Day before Maundy thursday
         }
 
         [TestMethod]


### PR DESCRIPTION
@martinjw: Found out that we actually needed to calculate the previous working day before a holiday. So I added this method to the library. You can decide yourself if this is useful functionality. 

Two additional comments: when only looking a the name NextWorkingDay you expect that it does not return the same date if that day is a working day. So maybe there should be some kind of overload or two seperate methods?

The NextWorkingDay and PreviousWorkingDay methods needs to be copied over to each implementation. Maybe a PublicHoliday abstract base class can be useful to avoid these kind of code copies. 