### PR TITLE
Add Swedish public holidays (de facto holidays, 'eves off' are included)

### DIFF
--- a/src/PublicHoliday/PublicHoliday2015.csproj
+++ b/src/PublicHoliday/PublicHoliday2015.csproj
@@ -52,6 +52,7 @@
     <Compile Include="KazakhstanPublicHoliday.cs" />
     <Compile Include="LuxembourgPublicHoliday.cs" />
     <Compile Include="NewZealandPublicHoliday.cs" />
+    <Compile Include="SwedenPublicHoliday.cs" />
     <Compile Include="NorwayPublicHoliday.cs" />
     <Compile Include="DutchPublicHoliday.cs" />
     <Compile Include="FrancePublicHoliday.cs" />

--- a/src/PublicHoliday/SwedenPublicHoliday.cs
+++ b/src/PublicHoliday/SwedenPublicHoliday.cs
@@ -1,0 +1,326 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PublicHoliday
+{
+    public class SwedenPublicHoliday : PublicHolidayBase
+    {
+
+        #region Individual Holidays
+
+        /// <summary>
+        /// New Year's Day January 1
+        /// </summary>
+        /// <param name="year">The year.</param>
+        /// <returns>Date of in the given year.</returns>
+        public static DateTime NewYear(int year)
+        {
+            return new DateTime(year, 1, 1);
+        }
+
+        /// <summary>
+        /// Epiphany - 13 days after christmas
+        /// </summary>
+        /// <param name="year">The year.</param>
+        /// <returns>Date of in the given year.</returns>
+        public static DateTime Epiphany(int year) {
+            return new DateTime(year, 1, 6);
+        }
+
+        /// <summary>
+        /// Good Friday - Friday before Easter
+        /// </summary>
+        /// <param name="year">The year.</param>
+        /// <returns>Date of in the given year.</returns>
+        public static DateTime GoodFriday(int year)
+        {
+            var hol = HolidayCalculator.GetEaster(year);
+            hol = hol.AddDays(-2);
+            return hol;
+        }
+
+        private static DateTime GoodFriday(DateTime easter)
+        {
+            return easter.AddDays(-2);
+        }
+
+        /// <summary>
+        /// Easter
+        /// </summary>
+        /// <param name="year">The year.</param>
+        /// <returns>Date of in the given year.</returns>
+        public static DateTime Easter(int year)
+        {
+            return HolidayCalculator.GetEaster(year);
+        }
+
+        /// <summary>
+        /// Easter Monday 1st Monday after Easter
+        /// </summary>
+        /// <param name="year">The year.</param>
+        /// <returns>Date of in the given year.</returns>
+        public static DateTime EasterMonday(int year)
+        {
+            var hol = HolidayCalculator.GetEaster(year);
+            hol = hol.AddDays(1);
+            return hol;
+        }
+
+        private static DateTime EasterMonday(DateTime easter)
+        {
+            return easter.AddDays(1);
+        }
+
+        /// <summary>
+        /// Labour Day - Mai 1st
+        /// </summary>
+        /// <param name="year">The year.</param>
+        /// <returns>Date of in the given year.</returns>
+        public static DateTime LabourDay(int year)
+        {
+            return new DateTime(year, 5, 1);
+        }
+
+        /// <summary>
+        /// Ascension 6th Thursday after Easter
+        /// </summary>
+        /// <param name="year">The year.</param>
+        /// <returns>Date of in the given year.</returns>
+        public static DateTime Ascension(int year)
+        {
+            var hol = HolidayCalculator.GetEaster(year);
+            hol = hol.AddDays(4 + (7 * 5));
+            return hol;
+        }
+
+        private static DateTime Ascension(DateTime easter)
+        {
+            return easter.AddDays(4 + (7 * 5));
+        }
+
+        /// <summary>
+        /// Whit Sunday - 7th Sunday after Easter
+        /// </summary>
+        /// <param name="year"></param>
+        /// <returns></returns>
+        public static DateTime WhitSunday(int year)
+        {
+            var hol = HolidayCalculator.GetEaster(year);
+            hol = hol.AddDays(7 * 7);
+            return hol;
+        }
+
+        private static DateTime WhitSunday(DateTime easter)
+        {
+            return easter.AddDays(7 * 7);
+        }
+
+        /// <summary>
+        /// National Day - June 6th
+        /// </summary>
+        /// <param name="year">The year.</param>
+        /// <returns>Date of in the given year.</returns>
+        public static DateTime NationalDay(int year) {
+            return new DateTime(year, 6, 6);
+        }
+
+        /// <summary>
+        /// Midsummer eve, first friday after June 19th
+        /// </summary>
+        /// <param name="year">The year.</param>
+        /// <returns>Date of in the given year.</returns>
+        public static DateTime MidsummerEve(int year) {
+            return GetMidsummer(year);
+        }
+
+        /// <summary>
+        /// Midsummer day, day after midsummer eve
+        /// </summary>
+        /// <param name="year">The year.</param>
+        /// <returns>Date of in the given year.</returns>
+        public static DateTime MidsummerDay(int year) {
+            return GetMidsummer(year).AddDays(1);
+        }
+
+        private static DateTime GetMidsummer(int year) {
+            DateTime dt = new DateTime(year, 6, 19);
+            for (int i = 0; i < 7; i++) {
+                if (dt.AddDays(i).DayOfWeek == DayOfWeek.Friday)
+                    return dt.AddDays(i);
+            }
+            return DateTime.MinValue;
+        }
+
+        /// <summary>
+        /// All saints day, day after all saints eve
+        /// First saturday after Oct. 31
+        /// </summary>
+        /// <param name="year">The year.</param>
+        /// <returns>Date of in the given year.</returns>
+        public static DateTime AllSaintsDay(int year) {
+            return GetAllSaintsDay(year);
+        }
+
+        private static DateTime GetAllSaintsDay(int year) {
+            DateTime dt = new DateTime(year, 10, 31);
+            for (int i = 0; i < 7; i++) {
+                if (dt.AddDays(i).DayOfWeek == DayOfWeek.Saturday)
+                    return dt.AddDays(i);
+            }
+            return DateTime.MinValue;
+        }
+
+        /// <summary>
+        /// Christmas Eve - December 24
+        /// </summary>
+        /// <param name="year"></param>
+        /// <returns></returns>
+        public static DateTime ChristmasEve(int year) {
+            return new DateTime(year, 12, 24);
+        }
+
+        /// <summary>
+        /// Christmas - December 25
+        /// </summary>
+        /// <param name="year"></param>
+        /// <returns></returns>
+        public static DateTime Christmas(int year)
+        {
+            return new DateTime(year, 12, 25);
+        }
+
+        /// <summary>
+        /// Boxing Day - December 26
+        /// </summary>
+        /// <param name="year"></param>
+        /// <returns></returns>
+        public static DateTime BoxingDay(int year)
+        {
+            return new DateTime(year, 12, 26);
+        }
+
+        /// <summary>
+        /// New Years Eve - December 31
+        /// </summary>
+        /// <param name="year"></param>
+        /// <returns></returns>
+        public static DateTime NewYearsEve(int year) {
+            return new DateTime(year, 12, 31);
+        }
+        
+        #endregion
+
+        /// <summary>
+        /// Get a list of dates for all holidays in a year.
+        /// </summary>
+        /// <param name="year">The year</param>
+        /// <returns>List of public holidays</returns>
+        public override IList<DateTime> PublicHolidays(int year)
+        {
+            return PublicHolidayNames(year).Select(x => x.Key).OrderBy(x => x).ToList();
+        }
+
+        /// <summary>
+        /// Public holiday names in Swedish.
+        /// </summary>
+        /// <param name="year">The year.</param>
+        /// <returns></returns>
+        public override IDictionary<DateTime, string> PublicHolidayNames(int year)
+        {
+            DateTime easter = HolidayCalculator.GetEaster(year);
+
+            var bHols = new Dictionary<DateTime, string>
+            {
+                {NewYear(year), "Nyårsdagen"},
+                {Epiphany(year), "Trettondag jul"},
+                {GoodFriday(easter), "Långfredag"},
+                {easter, "Påskdagen"},
+                {EasterMonday(easter), "Annandag påsk"},
+                {LabourDay(year), "Första maj"},
+                {Ascension(easter), "Kristi himmelfärds dag"},
+                {WhitSunday(easter), "Pingstdagen"},
+                {NationalDay(year), "Nationaldagen"},
+                {MidsummerEve(year), "Midsommarafton"},
+                {MidsummerDay(year), "Midsommardagen"},
+                {AllSaintsDay(year), "Alla helgons dag" },
+                {ChristmasEve(year), "Julafton"},
+                {Christmas(year), "Juldagen"},
+                {BoxingDay(year), "Annandag jul"},
+                {NewYearsEve(year), "Nyårsafton" }
+            };
+            return bHols;
+        }
+
+
+        /// <summary>
+        /// Check if a specific date is a public holiday.
+        /// Obviously the PublicHoliday list is more efficient for repeated checks
+        /// </summary>
+        /// <param name="dt">The date you wish to check</param>
+        /// <returns>True if date is a public holiday</returns>
+        public override bool IsPublicHoliday(DateTime dt)
+        {
+            var year = dt.Year;
+            var date = dt.Date;
+
+            switch (dt.Month)
+            {
+                case 1:
+                    if (NewYear(year) == date)
+                        return true;
+                    if (Epiphany(year) == date)
+                        return true;
+                    break;
+                case 3:
+                case 4:
+                    if (GoodFriday(year) == date)
+                        return true;
+                    if (HolidayCalculator.GetEaster(year) == date)
+                        return true;
+                    if (EasterMonday(year) == date)
+                        return true;
+                    if (Ascension(year) == date)
+                        return true;
+                    break;
+                case 5:
+                    if (LabourDay(year) == date)
+                        return true;
+                    if (Ascension(year) == date)
+                        return true;
+                    if (WhitSunday(year) == date)
+                        return true;
+                    break;
+                case 6:
+                    if (Ascension(year) == date)
+                        return true;
+                    if (WhitSunday(year) == date)
+                        return true;
+                    if (NationalDay(year) == date)
+                        return true;
+                    if (MidsummerEve(year) == date)
+                        return true;
+                    if (MidsummerDay(year) == date)
+                        return true;
+                    break;
+                case 11:
+                    if (AllSaintsDay(year) == date)
+                        return true;
+                    break;
+                case 12:
+                    if (ChristmasEve(year) == date)
+                        return true;
+                    if (Christmas(year) == date)
+                        return true;
+                    if (BoxingDay(year) == date)
+                        return true;
+                    if (NewYearsEve(year) == date) 
+                        return true;
+                    break;
+            }
+
+            return false;
+        }
+
+    }
+}

--- a/tests/PublicHolidayTests/PublicHolidayTests2015.csproj
+++ b/tests/PublicHolidayTests/PublicHolidayTests2015.csproj
@@ -49,6 +49,7 @@
     <Compile Include="CanadaPublicHolidayTests.cs" />
     <Compile Include="TestBelgiumPublicHoliday.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestSwedenPublicHoliday.cs" />
     <Compile Include="TestNorwayPublicHoliday.cs" />
     <Compile Include="TestSpainPublicHoliday.cs" />
     <Compile Include="TestUKBankHoliday.cs" />

--- a/tests/PublicHolidayTests/TestSwedenPublicHoliday.cs
+++ b/tests/PublicHolidayTests/TestSwedenPublicHoliday.cs
@@ -1,0 +1,194 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PublicHoliday;
+
+namespace PublicHolidayTests
+{
+    [TestClass]
+    public class TestSwedenPublicHoliday {
+        [TestMethod]
+        public void TestPublicHolidays() 
+        {
+            var easterMonday = new DateTime(2017, 4, 17);
+            var result = new SwedenPublicHoliday().PublicHolidayNames(2017);
+            Assert.AreEqual(16, result.Count);
+            Assert.IsTrue(result.ContainsKey(easterMonday));
+        }
+
+        [TestMethod]
+        public void TestIsPublicHoliday()
+        {
+            var isPublicHoliday = new SwedenPublicHoliday().IsPublicHoliday(new DateTime(2017, 4, 17));
+
+            Assert.IsTrue(isPublicHoliday, "Easter Monday");
+        }
+
+        [TestMethod]
+        public void TestIsNotPublicHoliday()
+        {
+            var isPublicHoliday = new SwedenPublicHoliday().IsPublicHoliday(new DateTime(2017, 4, 18));
+
+            Assert.IsFalse(isPublicHoliday, "Not a holiday");
+        }
+
+        [TestMethod]
+        public void TestNextWorkingDay()
+        {
+            var result = new SwedenPublicHoliday().NextWorkingDay(new DateTime(2017, 4, 14)); //Maundy thursday
+            Assert.AreEqual(new DateTime(2017, 4, 18), result); //Day after easter monday7
+        }
+
+        [TestMethod]
+        public void TestPreviousWorkingDay()
+        {
+            var result = new SwedenPublicHoliday().PreviousWorkingDay(new DateTime(2017, 4, 17)); //Easter monday
+            Assert.AreEqual(new DateTime(2017, 4, 13), result); //Day before good friday
+        }
+
+        [TestMethod]
+        public void TestNewYear2017()
+        {
+            var expected = new DateTime(2017, 1, 1);
+            var actual = SwedenPublicHoliday.NewYear(2017);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void TestGoodFriday2017()
+        {
+            var expected = new DateTime(2017, 4, 14);
+            var actual = SwedenPublicHoliday.GoodFriday(2017);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void TestEaster2017()
+        {
+            var expected = new DateTime(2017, 4, 16);
+            var actual = SwedenPublicHoliday.Easter(2017);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void TestEasterMonday2017()
+        {
+            var expected = new DateTime(2017, 4, 17);
+            var actual = SwedenPublicHoliday.EasterMonday(2017);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void TestLabourDay2017()
+        {
+            var expected = new DateTime(2017, 5, 1);
+            var actual = SwedenPublicHoliday.LabourDay(2017);
+            Assert.AreEqual(expected, actual);
+        }
+        
+        [TestMethod]
+        public void TestAscensionDay2017()
+        {
+            var expected = new DateTime(2017, 5, 25);
+            var actual = SwedenPublicHoliday.Ascension(2017);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void TestWhitSunday2017()
+        {
+            var expected = new DateTime(2017, 6, 4);
+            var actual = SwedenPublicHoliday.WhitSunday(2017);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void TestNationalDay2017() {
+            var expected = new DateTime(2017, 6, 6);
+            var actual = SwedenPublicHoliday.NationalDay(2017);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void TestMidsummerEve2017() {
+            var expected = new DateTime(2017, 6, 23);
+            var actual = SwedenPublicHoliday.MidsummerEve(2017);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void TestMidsummerDay2017() {
+            var expected = new DateTime(2017, 6, 24);
+            var actual = SwedenPublicHoliday.MidsummerDay(2017);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void TestAllSaintsDay2017() {
+            var expected = new DateTime(2017, 11, 4);
+            var actual = SwedenPublicHoliday.AllSaintsDay(2017);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void TestChristmasEve2017() {
+            var expected = new DateTime(2017, 12, 24);
+            var actual = SwedenPublicHoliday.ChristmasEve(2017);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void TestChristmas2017()
+        {
+            var expected = new DateTime(2017, 12, 25);
+            var actual = SwedenPublicHoliday.Christmas(2017);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void TestBoxingDay2017()
+        {
+            var expected = new DateTime(2017, 12, 26);
+            var actual = SwedenPublicHoliday.BoxingDay(2017);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void TestNewYearsEve2017() {
+            var expected = new DateTime(2017, 12, 31);
+            var actual = SwedenPublicHoliday.NewYearsEve(2017);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void TestIsPublicHoliday2017() {
+            var h = new SwedenPublicHoliday();
+
+            Assert.IsTrue(h.IsPublicHoliday(new DateTime(2017, 1, 1)));
+            Assert.IsFalse(h.IsPublicHoliday(new DateTime(2017, 1, 2)));
+            Assert.IsFalse(h.IsPublicHoliday(new DateTime(2017, 1, 5)));
+            Assert.IsTrue(h.IsPublicHoliday(new DateTime(2017, 1, 6)));
+            Assert.IsFalse(h.IsPublicHoliday(new DateTime(2017, 4, 13)));
+            Assert.IsTrue(h.IsPublicHoliday(new DateTime(2017, 4, 14)));
+            Assert.IsTrue(h.IsPublicHoliday(new DateTime(2017, 4, 16)));
+            Assert.IsTrue(h.IsPublicHoliday(new DateTime(2017, 4, 17)));
+            Assert.IsFalse(h.IsPublicHoliday(new DateTime(2017, 4, 18)));
+            Assert.IsFalse(h.IsPublicHoliday(new DateTime(2017, 4, 30)));
+            Assert.IsTrue(h.IsPublicHoliday(new DateTime(2017, 5, 1)));
+            Assert.IsFalse(h.IsPublicHoliday(new DateTime(2017, 5, 24)));
+            Assert.IsTrue(h.IsPublicHoliday(new DateTime(2017, 5, 25)));
+            Assert.IsFalse(h.IsPublicHoliday(new DateTime(2017, 5, 26)));
+            Assert.IsFalse(h.IsPublicHoliday(new DateTime(2017, 6, 5)));
+            Assert.IsTrue(h.IsPublicHoliday(new DateTime(2017, 6, 6)));
+            Assert.IsTrue(h.IsPublicHoliday(new DateTime(2017, 6, 23)));
+            Assert.IsTrue(h.IsPublicHoliday(new DateTime(2017, 6, 24)));
+            Assert.IsFalse(h.IsPublicHoliday(new DateTime(2017, 11, 3)));
+            Assert.IsTrue(h.IsPublicHoliday(new DateTime(2017, 11, 4)));
+            Assert.IsFalse(h.IsPublicHoliday(new DateTime(2017, 12, 23)));
+            Assert.IsTrue(h.IsPublicHoliday(new DateTime(2017, 12, 24)));
+            Assert.IsTrue(h.IsPublicHoliday(new DateTime(2017, 12, 25)));
+            Assert.IsTrue(h.IsPublicHoliday(new DateTime(2017, 12, 26)));
+            Assert.IsFalse(h.IsPublicHoliday(new DateTime(2017, 12, 30)));
+            Assert.IsTrue(h.IsPublicHoliday(new DateTime(2017, 12, 31)));
+        }
+    }
+}


### PR DESCRIPTION
Added Swedish public holidays. Decided to include "de facto" holiday like Midsummer Eve. 

Depends on the intended audience what we want to include here...

http://www.officeholidays.com/countries/sweden/
https://www.timeanddate.com/holidays/sweden/