### PR TITLE
Fixed build error in VS2015

### DIFF
--- a/src/PublicHoliday/PublicHoliday2015.csproj
+++ b/src/PublicHoliday/PublicHoliday2015.csproj
@@ -47,6 +47,7 @@
     <Compile Include="BelgiumPublicHoliday.cs" />
     <Compile Include="CanadaPublicHoliday.cs" />
     <Compile Include="GermanPublicHoliday.cs" />
+    <Compile Include="Holiday.cs" />
     <Compile Include="IrelandPublicHoliday.cs" />
     <Compile Include="ItalyPublicHoliday.cs" />
     <Compile Include="KazakhstanPublicHoliday.cs" />


### PR DESCRIPTION
 - Holiday.cs added to PublicHoliday2015.csproj