### PR TITLE
Fix #25 - Thanksgiving is the 4th Thursday of November.

### DIFF
--- a/src/PublicHoliday/USAPublicHoliday.cs
+++ b/src/PublicHoliday/USAPublicHoliday.cs
@@ -124,11 +124,8 @@ namespace PublicHoliday
         /// <returns></returns>
         public static Holiday Thanksgiving(int year)
         {
-            var hol = new DateTime(year, 11, 23);
-            while (hol.DayOfWeek != DayOfWeek.Thursday)
-            {
-                hol = hol.AddDays(1);
-            }
+            var hol = new DateTime(year, 11, 22);
+            hol = HolidayCalculator.FindOccurrenceOfDayOfWeek(hol, DayOfWeek.Thursday, 1);
             return new Holiday(hol, hol);
         }
 

--- a/tests/PublicHolidayTests/TestUSPublicHoliday.cs
+++ b/tests/PublicHolidayTests/TestUSPublicHoliday.cs
@@ -12,6 +12,14 @@ namespace PublicHolidayTests
     public class TestUSPublicHoliday
     {
         [TestMethod]
+        public void TestThanksgiving2018()
+        {
+            var expected = new DateTime(2018, 11, 22);
+            var actual = USAPublicHoliday.Thanksgiving(2018);
+            Assert.AreEqual(expected, actual);
+        }
+
+         [TestMethod]
         public void TestNewYear2004()
         {
             var expected = new DateTime(2004, 1, 1);


### PR DESCRIPTION
 Making it not before 11/22.

Implementing in the same style as LaborDay and other holidays.