### PR TITLE
UK Early May Day 2020 moved

### DIFF
--- a/src/PublicHoliday/UKBankHoliday.cs
+++ b/src/PublicHoliday/UKBankHoliday.cs
@@ -70,6 +70,9 @@ namespace PublicHoliday
             if (year < 1978) return null;
             if (year == 1995)
                 return new DateTime(1995, 5, 8); //1995 moved for 50th anniversary of VE day
+            if (year == 2020)
+                return new DateTime(2020, 5, 8); // 2020 moved for 75th anniversary of VE day
+            
             DateTime hol = new DateTime(year, 5, 1);
             hol = HolidayCalculator.FindFirstMonday(hol);
             return hol;

--- a/tests/PublicHolidayTests/TestUKBankHoliday.cs
+++ b/tests/PublicHolidayTests/TestUKBankHoliday.cs
@@ -66,6 +66,17 @@ namespace PublicHolidayTests
         }
 
         /// <summary>
+        /// Test May Day in 2020 (Moved to the 8th/May)
+        /// </summary>
+        [TestMethod]
+        public void TestMayDay2020()
+        {
+            var expected = new DateTime(2020, 5, 8);
+            var actual = UKBankHoliday.MayDay(2020);
+            Assert.AreEqual(expected, actual.Value);
+        }
+
+        /// <summary>
         /// New Year is a Sunday, so bank holiday is Monday
         /// </summary>
         [TestMethod]


### PR DESCRIPTION
This fixes the Early May Day Bank Holiday to be on the 8th May due to the 75th anniversary of VE day.
Note that as at this time this applies to England, Wales and NI but Scotland is yet to approve this (but is widely expected to, and I can't see where Scottish Bank Holidays are defined, as they are different)