### PR TITLE
Add dates for Matariki for the next 30 years

### DIFF
--- a/src/PublicHoliday/NewZealandPublicHoliday.cs
+++ b/src/PublicHoliday/NewZealandPublicHoliday.cs
@@ -130,6 +130,53 @@ namespace PublicHoliday
         }
 
         /// <summary>
+        /// Matariki - https://www.beehive.govt.nz/release/matariki-holiday-dates-next-thirty-years-announced
+        /// </summary>
+        /// <param name="year">The year to check</param>
+        /// <returns>The date of Matariki, if there is one defined</returns>
+        public static DateTime? Matariki(int year)
+        {
+            // First occurrence is in 2022
+            if (year < 2022) return null;
+
+            var dates = new Dictionary<int, DateTime>
+            {
+                {2022, new DateTime(2022, 6, 24)},
+                {2023, new DateTime(2023, 7, 14)},
+                {2024, new DateTime(2024, 6, 28)},
+                {2025, new DateTime(2025, 6, 20)},
+                {2026, new DateTime(2026, 7, 10)},
+                {2027, new DateTime(2027, 6, 25)},
+                {2028, new DateTime(2028, 7, 14)},
+                {2029, new DateTime(2029, 7, 6)},
+                {2030, new DateTime(2030, 6, 21)},
+                {2031, new DateTime(2031, 7, 11)},
+                {2032, new DateTime(2032, 7, 2)},
+                {2033, new DateTime(2033, 6, 24)},
+                {2034, new DateTime(2034, 7, 7)},
+                {2036, new DateTime(2036, 7, 18)},
+                {2037, new DateTime(2037, 7, 10)},
+                {2038, new DateTime(2038, 6, 25)},
+                {2039, new DateTime(2039, 7, 15)},
+                {2040, new DateTime(2040, 7, 6)},
+                {2041, new DateTime(2041, 7, 19)},
+                {2042, new DateTime(2042, 7, 11)},
+                {2043, new DateTime(2043, 7, 3)},
+                {2044, new DateTime(2044, 6, 24)},
+                {2045, new DateTime(2045, 7, 7)},
+                {2046, new DateTime(2046, 6, 29)},
+                {2047, new DateTime(2047, 7, 19)},
+                {2048, new DateTime(2048, 7, 3)},
+                {2049, new DateTime(2049, 6, 25)},
+                {2050, new DateTime(2050, 7, 15)},
+                {2051, new DateTime(2051, 6, 30)},
+                {2052, new DateTime(2052, 6, 21)}
+            };
+            
+            return dates.ContainsKey(year) ? dates[year] : (DateTime?)null;
+        }
+
+        /// <summary>
         /// Get a list of dates for all holidays in a year.
         /// </summary>
         /// <param name="year">The year.</param>
@@ -162,6 +209,12 @@ namespace PublicHoliday
             bHols.Add(LabourDay(year), "Labour Day");
             bHols.Add(Christmas(year), "Christmas Day");
             bHols.Add(BoxingDay(year), "Boxing Day");
+
+            var matariki = Matariki(year);
+            if (matariki.HasValue)
+            {
+                bHols.Add(matariki.Value, "Matariki");
+            }
             return bHols;
         }
 
@@ -201,6 +254,12 @@ namespace PublicHoliday
                     break;
                 case 6:
                     if (QueenBirthday(year) == date)
+                        return true;
+                    if (Matariki(year) == date)
+                        return true;
+                    break;
+                case 7:
+                    if (Matariki(year) == date)
                         return true;
                     break;
                 case 10:

--- a/src/PublicHoliday/PublicHoliday.csproj
+++ b/src/PublicHoliday/PublicHoliday.csproj
@@ -18,7 +18,8 @@
 2.2.0: Japan 2020 error (thanks @overstimulated)
 2.3.0: UK 2022 Queen's Platinum Jubilee
 2.4.0: Scotland, Northern Island holidays (thanks @stuart-lawrence)
-2.5.0: US 2021 Juneteenth added</PackageReleaseNotes>
+2.5.0: US 2021 Juneteenth added
+2.6.0: New Zealand Matariki dates added for next 30 years</PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/martinjw/Holiday</PackageProjectUrl>
     <PackageLicenseUrl>http://opensource.org/licenses/MIT</PackageLicenseUrl>
     <RepositoryType>git</RepositoryType>

--- a/tests/PublicHolidayTests/TestNewZealandPublicHoliday.cs
+++ b/tests/PublicHolidayTests/TestNewZealandPublicHoliday.cs
@@ -81,5 +81,29 @@ namespace PublicHolidayTests
             Assert.IsTrue(10 == hols.Count, "Should be 10 holidays in 2017");
             Assert.IsTrue(holNames.Count == hols.Count, "Names and holiday list are same");
         }
+
+        [TestMethod]
+        public void TestHolidays2022Lists()
+        {
+            var holidayCalendar = new NewZealandPublicHoliday();
+            var hols = holidayCalendar.PublicHolidays(2022);
+            var holNames = holidayCalendar.PublicHolidayNames(2022);
+            Assert.IsTrue(11 == hols.Count, "Should be 11 holidays in 2022");
+            Assert.IsTrue(holNames.Count == hols.Count, "Names and holiday list are same");
+        }
+
+        [TestMethod]
+        public void TestMatarikiBeforeIntroduction()
+        {
+            var matariki = NewZealandPublicHoliday.Matariki(2021);
+            Assert.IsNull(matariki, "Matariki first occurs as a public holiday in 2022");
+        }
+
+        [TestMethod]
+        public void TestMatarikiAfterIntroduction()
+        {
+            var matariki = NewZealandPublicHoliday.Matariki(2025);
+            Assert.AreEqual(new DateTime(2025, 6, 20), matariki, "Matariki should be on 25th June 2025");
+        }
     }
 }


### PR DESCRIPTION
Dates for a new public holiday in New Zealand have been published by the New Zealand Government, adding this in as a holiday from 2022 onwards.

https://www.beehive.govt.nz/release/matariki-holiday-dates-next-thirty-years-announced