### PR TITLE
ANZAC Day could share the same day as Easter Monday, so need to allow for this to happen

### DIFF
--- a/src/PublicHoliday/NewZealandPublicHoliday.cs
+++ b/src/PublicHoliday/NewZealandPublicHoliday.cs
@@ -204,7 +204,13 @@ namespace PublicHoliday
             var easter = HolidayCalculator.GetEaster(year);
             bHols.Add(GoodFriday(easter), "Good Friday");
             bHols.Add(EasterMonday(easter), "Easter Monday");
-            bHols.Add(AnzacDay(year), "Anzac Day");
+            
+            // ANZAC Day could share the same day as Good Friday or Easter Monday - https://www.employment.govt.nz/leave-and-holidays/public-holidays/public-holidays-and-anniversary-dates/dates-for-previous-years/ (2011)
+            var anzacDay = AnzacDay(year);
+            if(bHols.ContainsKey(anzacDay)) {
+                anzacDay = anzacDay.AddSeconds(1);
+            }
+            bHols.Add(anzacDay, "ANZAC Day");
             bHols.Add(QueenBirthday(year), "Queen's Birthday");
             bHols.Add(LabourDay(year), "Labour Day");
             bHols.Add(Christmas(year), "Christmas Day");

--- a/tests/PublicHolidayTests/TestNewZealandPublicHoliday.cs
+++ b/tests/PublicHolidayTests/TestNewZealandPublicHoliday.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using PublicHoliday;
 using System;
+using System.Linq;
 
 namespace PublicHolidayTests
 {
@@ -70,6 +71,21 @@ namespace PublicHolidayTests
             var actual = NewZealandPublicHoliday.AnzacDay(2020);
             var expected = new DateTime(2020, 4, 27); // Observed to Monday the 27th.
             Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void AnzacDaySameDayAsEasterMonday2011() {
+            var holidayCalendar = new NewZealandPublicHoliday();
+            var hols = holidayCalendar.PublicHolidayNames(2011);
+            Assert.IsTrue(10 == hols.Count, "Should be 10 holidays in 2011");
+
+            var (anzacDay, _) = hols.FirstOrDefault(x => x.Value.Equals("ANZAC Day", StringComparison.CurrentCultureIgnoreCase));
+            var (easterMonday, _) = hols.FirstOrDefault(x => x.Value.Equals("Easter Monday", StringComparison.CurrentCultureIgnoreCase));
+
+            Assert.IsFalse(anzacDay == default(DateTime), "ANZAC Day not found in 2011");
+            Assert.IsFalse(easterMonday == default(DateTime), "Easter Monday not found in 2011");
+
+            Assert.IsTrue(anzacDay.Date.Equals(easterMonday.Date), $"ANZAC Day and Easter Monday fell on the same day in 2011");
         }
 
         [TestMethod]


### PR DESCRIPTION
Discovered while trying to fetch dates in the somewhat far future (2038) and was getting "System.ArgumentException: An item with the same key has already been added." whilst calling `PublicHolidayNames` for that year.

I also observed this happening for 2011 and confirmed that for this year that both holidays were observed on the same day (https://www.employment.govt.nz/leave-and-holidays/public-holidays/public-holidays-and-anniversary-dates/dates-for-previous-years/)