### PR TITLE
Add State Funeral for QEII for Canada, National Day of Mourning for Aus/NZ

### DIFF
--- a/src/PublicHoliday/AustraliaPublicHoliday.cs
+++ b/src/PublicHoliday/AustraliaPublicHoliday.cs
@@ -379,6 +379,11 @@ namespace PublicHoliday
             }
             bHols.Add(Christmas(year), "Christmas Day");
             bHols.Add(BoxingDay(year), State == States.SA ? "Proclamation Day" : "Boxing Day");
+
+            if (year == 2022)
+            {
+                bHols.Add(new DateTime(2022, 9, 22), "National Day of Mourning");
+            }
             return bHols;
         }
 
@@ -494,6 +499,9 @@ namespace PublicHoliday
                 //variable months
                 if (FamilyAndCommunityDay(year) == date) return true;
             }
+
+            // National Day of Mourning (for the death of Queen Elizabeth II)
+            if (year == 2022 && dt.Month == 9 && dt.Day == 22) return true;
 
             return false;
         }

--- a/src/PublicHoliday/CanadaPublicHoliday.cs
+++ b/src/PublicHoliday/CanadaPublicHoliday.cs
@@ -527,6 +527,9 @@ namespace PublicHoliday
 
             if (HasBoxingDay(Province))
                 bHols.Add(BoxingDay(year), "Boxing Day");
+            
+            if(year == 2022)
+                bHols.Add(new DateTime(2022, 9, 19), "State Funeral of Queen Elizabeth II");
 
             return bHols;
         }

--- a/src/PublicHoliday/NewZealandPublicHoliday.cs
+++ b/src/PublicHoliday/NewZealandPublicHoliday.cs
@@ -216,6 +216,11 @@ namespace PublicHoliday
             bHols.Add(Christmas(year), "Christmas Day");
             bHols.Add(BoxingDay(year), "Boxing Day");
 
+            if (2022 == year)
+            {
+                bHols.Add(new DateTime(2022, 9, 26), "National Day of Mourning");
+            }
+
             var matariki = Matariki(year);
             if (matariki.HasValue)
             {
@@ -279,6 +284,10 @@ namespace PublicHoliday
                         return true;
                     break;
             }
+
+            // National Day of Mourning (for the death of Queen Elizabeth II)
+            if (year == 2022 && dt.Month == 9 && dt.Day == 26) return true;
+            
             return false;
         }
     }

--- a/tests/PublicHolidayTests/TestAustraliaPublicHoliday.cs
+++ b/tests/PublicHolidayTests/TestAustraliaPublicHoliday.cs
@@ -35,6 +35,17 @@ namespace PublicHolidayTests
             Assert.IsTrue(7 == hols.Count, "Should be 7 holidays in 2017");
             Assert.IsTrue(holNames.Count == hols.Count, "Names and holiday list are same");
         }
+        
+        [TestMethod]
+        public void TestHolidays2022Lists()
+        {
+            var holidayCalendar = new AustraliaPublicHoliday(); //ALL states - just 7 national
+            var hols = holidayCalendar.PublicHolidays(2022);
+            var holNames = holidayCalendar.PublicHolidayNames(2022);
+            //New Year's Day, Australia Day, Good Friday, Easter Monday, Anzac Day, National Day of Mourning, Christmas Day and Boxing Day
+            Assert.IsTrue(8 == hols.Count, "Should be 8 holidays in 2022");
+            Assert.IsTrue(holNames.Count == hols.Count, "Names and holiday list are same");
+        }
 
         [DataTestMethod]
         [DataRow(1, 2, "new year (sunday, so monday is holiday)")]

--- a/tests/PublicHolidayTests/TestCanadaPublicHoliday.cs
+++ b/tests/PublicHolidayTests/TestCanadaPublicHoliday.cs
@@ -78,6 +78,15 @@ namespace PublicHolidayTests
         }
 
         [TestMethod]
+        public void PublicHoliday2022Test()
+        {
+            var result = new CanadaPublicHoliday().PublicHolidays(2022);
+            Assert.AreEqual(13, result.Count);
+            
+            Assert.IsTrue(new CanadaPublicHoliday().IsPublicHoliday(new DateTime(2022, 9, 19)));
+        }
+
+        [TestMethod]
         public void CivicDayProvincalTest()
         {
             //provincal holiday but not a national one

--- a/tests/PublicHolidayTests/TestNewZealandPublicHoliday.cs
+++ b/tests/PublicHolidayTests/TestNewZealandPublicHoliday.cs
@@ -19,7 +19,7 @@ namespace PublicHolidayTests
         [DataRow(10, 23, "labour day")]
         [DataRow(12, 25, "christmas")]
         [DataRow(12, 26, "boxing day")]
-        public void TestWesternAustralia2017(int month, int day, string name)
+        public void TestNewZealand2017(int month, int day, string name)
         {
             var holiday = new DateTime(2017, month, day);
             var holidayCalendar = new NewZealandPublicHoliday();
@@ -104,6 +104,16 @@ namespace PublicHolidayTests
             var holidayCalendar = new NewZealandPublicHoliday();
             var hols = holidayCalendar.PublicHolidays(2022);
             var holNames = holidayCalendar.PublicHolidayNames(2022);
+            Assert.IsTrue(12 == hols.Count, "Should be 12 holidays in 2022");
+            Assert.IsTrue(holNames.Count == hols.Count, "Names and holiday list are same");
+        }
+
+        [TestMethod]
+        public void TestHolidays2023Lists()
+        {
+            var holidayCalendar = new NewZealandPublicHoliday();
+            var hols = holidayCalendar.PublicHolidays(2023);
+            var holNames = holidayCalendar.PublicHolidayNames(2023);
             Assert.IsTrue(11 == hols.Count, "Should be 11 holidays in 2022");
             Assert.IsTrue(holNames.Count == hols.Count, "Names and holiday list are same");
         }


### PR DESCRIPTION
#71 

Adding in one-off public holidays for Canada (State Funeral), Australia and New Zealand (National Day of Mourning) for recognising the death of Queen Elizabeth II

Refs:

https://www.smh.com.au/politics/federal/albanese-announces-public-holiday-to-mark-queen-s-death-20220911-p5bh4e.html
https://www.rnz.co.nz/news/national/474609/cabinet-announces-one-off-public-holiday-to-mark-death-of-queen-elizabeth-ii
