### PR TITLE
South african public holidays fixes

### DIFF
--- a/src/PublicHoliday/HolidayCalculator.cs
+++ b/src/PublicHoliday/HolidayCalculator.cs
@@ -112,6 +112,18 @@ namespace PublicHoliday
         }
 
         /// <summary>
+        /// Fix weekend with only sunday to monday.
+        /// </summary>
+        /// <param name="hol"></param>
+        /// <returns></returns>
+        public static DateTime FixWeekendSundayAfter(DateTime hol)
+        {
+            if (hol.DayOfWeek == DayOfWeek.Sunday)
+                hol = hol.AddDays(1);
+            return hol;
+        }
+
+        /// <summary>
         /// Fix Weekend for the after of two holiday consecutive with standard FixWeekend to monday.
         /// </summary>
         /// <param name="hol"></param>

--- a/src/PublicHoliday/SouthAfricaPublicHoliday.cs
+++ b/src/PublicHoliday/SouthAfricaPublicHoliday.cs
@@ -212,6 +212,10 @@ namespace PublicHoliday
                 case 3:
                     if (HumanRightsDay(year) == date)
                         return true;
+                    if (GoodFriday(year) == date)
+                        return true;
+                    if (EasterMonday(year) == date)
+                        return true;
                     break;
 
                 case 4:

--- a/src/PublicHoliday/SouthAfricaPublicHoliday.cs
+++ b/src/PublicHoliday/SouthAfricaPublicHoliday.cs
@@ -21,7 +21,7 @@ namespace PublicHoliday
         /// <returns>Date of in the given year.</returns>
         public static DateTime NewYear(int year)
         {
-            return HolidayCalculator.FixWeekend(new DateTime(year, 1, 1));
+            return HolidayCalculator.FixWeekendSundayAfter(new DateTime(year, 1, 1));
         }
 
         /// <summary>
@@ -31,7 +31,7 @@ namespace PublicHoliday
 
         public static DateTime HumanRightsDay(int year)
         {
-            return HolidayCalculator.FixWeekend(new DateTime(year, 3, 21));
+            return HolidayCalculator.FixWeekendSundayAfter(new DateTime(year, 3, 21));
         }
 
         /// <summary>
@@ -72,7 +72,7 @@ namespace PublicHoliday
 
         public static DateTime FreedomDay(int year)
         {
-            return HolidayCalculator.FixWeekend(new DateTime(year, 4, 27));
+            return HolidayCalculator.FixWeekendSundayAfter(new DateTime(year, 4, 27));
         }
 
 
@@ -83,7 +83,7 @@ namespace PublicHoliday
         /// 
         public static DateTime LabourDay(int year)
         {
-            return HolidayCalculator.FixWeekend(new DateTime(year, 5, 1));
+            return HolidayCalculator.FixWeekendSundayAfter(new DateTime(year, 5, 1));
         }
 
         /// <summary>
@@ -93,7 +93,7 @@ namespace PublicHoliday
 
         public static DateTime YouthDay(int year)
         {
-            return HolidayCalculator.FixWeekend(new DateTime(year, 6, 16));
+            return HolidayCalculator.FixWeekendSundayAfter(new DateTime(year, 6, 16));
         }
 
         /// <summary>
@@ -103,7 +103,7 @@ namespace PublicHoliday
 
         public static DateTime NationalWomensDay(int year)
         {
-            return HolidayCalculator.FixWeekend(new DateTime(year, 8, 9));
+            return HolidayCalculator.FixWeekendSundayAfter(new DateTime(year, 8, 9));
         }
 
         /// <summary>
@@ -113,7 +113,7 @@ namespace PublicHoliday
 
         public static DateTime HeritageDay(int year)
         {
-            return HolidayCalculator.FixWeekend(new DateTime(year, 9, 24));
+            return HolidayCalculator.FixWeekendSundayAfter(new DateTime(year, 9, 24));
         }
 
         /// <summary>
@@ -123,7 +123,7 @@ namespace PublicHoliday
 
         public static DateTime ReconciliationDay(int year)
         {
-            return HolidayCalculator.FixWeekend(new DateTime(year, 12, 16));
+            return HolidayCalculator.FixWeekendSundayAfter(new DateTime(year, 12, 16));
         }
 
         /// <summary>
@@ -133,7 +133,8 @@ namespace PublicHoliday
         /// <returns></returns>
         public static DateTime Christmas(int year)
         {
-            return HolidayCalculator.FixWeekend(new DateTime(year, 12, 25));
+            //Christmas does not shift when it falls on a Sunday due to boxing day being on the Monday then.
+            return new DateTime(year, 12, 25);
         }
 
         /// <summary>
@@ -143,15 +144,8 @@ namespace PublicHoliday
         /// <returns></returns>
         public static DateTime BoxingDay(int year)
         {
-            DateTime hol = new DateTime(year, 12, 26);
-            //if Xmas=Sun, it's shifted to Mon and 26 also gets shifted
-            bool isSundayOrMonday =
-                hol.DayOfWeek == DayOfWeek.Sunday ||
-                hol.DayOfWeek == DayOfWeek.Monday;
-            hol = HolidayCalculator.FixWeekend(hol);
-            if (isSundayOrMonday)
-                hol = hol.AddDays(1);
-            return hol;
+            //Boxing day does not shift when it falls on a 
+            return HolidayCalculator.FixWeekendSundayAfter(new DateTime(year, 12, 26));
         }
 
         #endregion Individual Holidays

--- a/tests/PublicHolidayTests/TestSouthAfricaPublicHoliday.cs
+++ b/tests/PublicHolidayTests/TestSouthAfricaPublicHoliday.cs
@@ -69,7 +69,7 @@ namespace PublicHolidayTests
         }
 
         [TestMethod]
-        public void TestChristmasAndBoxingDay2022()
+        public void TestChristmasAndBoxingDay2021()
         {
             var christmasDay = SouthAfricaPublicHoliday.Christmas(2021);
             var boxingDay = SouthAfricaPublicHoliday.BoxingDay(2021);

--- a/tests/PublicHolidayTests/TestSouthAfricaPublicHoliday.cs
+++ b/tests/PublicHolidayTests/TestSouthAfricaPublicHoliday.cs
@@ -17,7 +17,6 @@ namespace PublicHolidayTests
         [DataRow(6, 16, "Youth Day")]
         [DataRow(8, 9, "National Women's Day")]
         [DataRow(9, 25, "Heritage Day")]
-        [DataRow(12, 18, "Day of Reconciliation")]
         [DataRow(12, 25, "christmas")]
         [DataRow(12, 26, "boxing day")]
         public void TestHolidays2017(int month, int day, string name)
@@ -35,6 +34,77 @@ namespace PublicHolidayTests
             var hols = holidayCalendar.PublicHolidays(2017);
             var holNames = holidayCalendar.PublicHolidayNames(2017);
             Assert.IsTrue(12 == hols.Count, "Should be 12 holidays in 2017");
+            Assert.IsTrue(holNames.Count == hols.Count, "Names and holiday list are same");
+        }
+
+
+        [DataTestMethod]
+        [DataRow(3, 22, "Human Rights Day - Observed on Monday")]
+        [DataRow(4, 2, "Good Friday")]
+        [DataRow(4, 5, "Family Day")]
+        [DataRow(4, 27, "Freedom Day")]
+        [DataRow(5, 1, "Workers' Day")]
+        [DataRow(6, 16, "Youth Day")]
+        [DataRow(8, 9, "National Women's Day")]
+        [DataRow(9, 24, "Heritage Day")]
+        [DataRow(12, 16, "Day of reconciliation")]
+        [DataRow(12, 25, "Christmas")]
+        [DataRow(12, 27, "Boxing day - Observed on Monday")]
+        public void TestHolidays2021(int month, int day, string name)
+        {
+            var holiday = new DateTime(2021, month, day);
+            var holidayCalendar = new SouthAfricaPublicHoliday();
+            var actual = holidayCalendar.IsPublicHoliday(holiday);
+            Assert.IsTrue(actual, $"{holiday.ToString("D")} is not a holiday -{name}");
+        }
+
+        [TestMethod]
+        public void TestHolidays2021Lists()
+        {
+            var holidayCalendar = new SouthAfricaPublicHoliday();
+            var hols = holidayCalendar.PublicHolidays(2021);
+            var holNames = holidayCalendar.PublicHolidayNames(2021);
+            Assert.IsTrue(12 == hols.Count, "Should be 12 holidays in 2021");
+            Assert.IsTrue(holNames.Count == hols.Count, "Names and holiday list are same");
+        }
+
+        [TestMethod]
+        public void TestChristmasAndBoxingDay2022()
+        {
+            var christmasDay = SouthAfricaPublicHoliday.Christmas(2021);
+            var boxingDay = SouthAfricaPublicHoliday.BoxingDay(2021);
+
+            Assert.AreNotEqual(new DateTime(2021, 12, 26), christmasDay, "Christmas day cannot move to Monday because Boxing day falls on Monday ");
+            Assert.AreEqual(new DateTime(2021, 12, 27), boxingDay, "Boxing day should be observed on Monday 27 Dec 2021");
+        }
+
+        [DataTestMethod]
+        [DataRow(3, 21, "Human Rights Day")]
+        [DataRow(4, 15, "Good Friday")]
+        [DataRow(4, 18, "Family Day")]
+        [DataRow(4, 27, "Freedom Day")]
+        [DataRow(5, 2, "Workers' Day - Observed on Monday")]
+        [DataRow(6, 16, "Youth Day")]
+        [DataRow(8, 9, "National Women's Day")]
+        [DataRow(9, 24, "Heritage Day")]
+        [DataRow(12, 16, "Day of reconciliation")]
+        [DataRow(12, 25, "Christmas")]
+        [DataRow(12, 26, "Boxing day")]
+        public void TestHolidays2022(int month, int day, string name)
+        {
+            var holiday = new DateTime(2022, month, day);
+            var holidayCalendar = new SouthAfricaPublicHoliday();
+            var actual = holidayCalendar.IsPublicHoliday(holiday);
+            Assert.IsTrue(actual, $"{holiday.ToString("D")} is not a holiday -{name}");
+        }
+
+        [TestMethod]
+        public void TestHolidays2022Lists()
+        {
+            var holidayCalendar = new SouthAfricaPublicHoliday();
+            var hols = holidayCalendar.PublicHolidays(2022);
+            var holNames = holidayCalendar.PublicHolidayNames(2022);
+            Assert.IsTrue(12 == hols.Count, "Should be 12 holidays in 2022");
             Assert.IsTrue(holNames.Count == hols.Count, "Names and holiday list are same");
         }
     }

--- a/tests/PublicHolidayTests/TestSouthAfricaPublicHoliday.cs
+++ b/tests/PublicHolidayTests/TestSouthAfricaPublicHoliday.cs
@@ -107,5 +107,50 @@ namespace PublicHolidayTests
             Assert.IsTrue(12 == hols.Count, "Should be 12 holidays in 2022");
             Assert.IsTrue(holNames.Count == hols.Count, "Names and holiday list are same");
         }
+
+
+
+        [DataTestMethod]
+        [DataRow(1, 2, "New Years Day - Observed on Monday")]
+        [DataRow(3, 21, "Human Rights Day")]
+        [DataRow(4, 7, "Good Friday")]
+        [DataRow(4, 10, "Family Day")]
+        [DataRow(4, 27, "Freedom Day")]
+        [DataRow(5, 1, "Workers' Day")]
+        [DataRow(6, 16, "Youth Day")]
+        [DataRow(8, 9, "National Women's Day")]
+        [DataRow(9, 25, "Heritage Day - Observed on Monday")]
+        [DataRow(12, 16, "Day of reconciliation")]
+        [DataRow(12, 25, "Christmas")]
+        [DataRow(12, 26, "Boxing day")]
+        public void TestHolidays2023(int month, int day, string name)
+        {
+            var holiday = new DateTime(2023, month, day);
+            var holidayCalendar = new SouthAfricaPublicHoliday();
+            var actual = holidayCalendar.IsPublicHoliday(holiday);
+            Assert.IsTrue(actual, $"{holiday.ToString("D")} is not a holiday -{name}");
+        }
+
+        [DataTestMethod]
+        [DataRow(1, 1, "New Years Day")]
+        [DataRow(3, 21, "Human Rights Day")]
+        [DataRow(3, 29, "Good Friday")]
+        [DataRow(4, 1, "Family Day")]
+        [DataRow(4, 27, "Freedom Day")]
+        [DataRow(5, 1, "Workers' Day")]
+        [DataRow(6, 17, "Youth Day - Observed on Monday")]
+        [DataRow(8, 9, "National Women's Day")]
+        [DataRow(9, 24, "Heritage Day")]
+        [DataRow(12, 16, "Day of reconciliation")]
+        [DataRow(12, 25, "Christmas")]
+        [DataRow(12, 26, "Boxing day")]
+        public void TestHolidays2024(int month, int day, string name)
+        {
+            var x = SouthAfricaPublicHoliday.GoodFriday(2024);
+            var holiday = new DateTime(2024, month, day);
+            var holidayCalendar = new SouthAfricaPublicHoliday();
+            var actual = holidayCalendar.IsPublicHoliday(holiday);
+            Assert.IsTrue(actual, $"{holiday.ToString("D")} is not a holiday -{name}");
+        }
     }
 }


### PR DESCRIPTION
For the SouthAfricaPublicHoliday implementation, the rules in South Africa are slightly different in that only public holidays that fall on a Sunday are carried over to the following Monday. Public holidays that fall on a Saturday do not get observed on another day. There are also some complexities around Christmas day and Boxing day.

I've added tests for all the scenarios and all tests are passing.