### PR TITLE
Germany: Assumption/Mariä Himmelfahrt is a public holiday in most parts of Bavaria

### DIFF
--- a/src/PublicHoliday/GermanPublicHoliday.cs
+++ b/src/PublicHoliday/GermanPublicHoliday.cs
@@ -226,7 +226,7 @@ namespace PublicHoliday
         /// <value>
         /// <c>true</c> if this state observes Mariä Himmelfahrt; otherwise, <c>false</c>.
         /// </value>
-        public bool HasAssumption => States.SL == State;
+        public bool HasAssumption => States.SL == State  || States.BY == State;
 
         /// <summary>
         /// Kindertag - World Children's Day

--- a/tests/PublicHolidayTests/TestGermanyPublicHoliday.cs
+++ b/tests/PublicHolidayTests/TestGermanyPublicHoliday.cs
@@ -78,7 +78,7 @@ namespace PublicHolidayTests
             var hols = holidayCalendar.PublicHolidays(2017);
             var holNames = holidayCalendar.PublicHolidayNames(2017);
             //technically, Bavaria widely observes Assumption/Mariä Himmelfahrt on August 15
-            Assert.IsTrue(13 == hols.Count, "Should be 13 holidays in 2017 - 500th anniversary Reformation");
+            Assert.IsTrue(14 == hols.Count, "Should be 14 holidays in 2017 - 500th anniversary Reformation");
             Assert.IsTrue(holNames.Count == hols.Count, "Names and holiday list are same");
         }
 


### PR DESCRIPTION
Assumption/Mariä Himmelfahrt is a public holiday in most parts of Bavaria (see https://www.statistik.bayern.de/mam/presse/2023/214_2023_44_a_mariae_himmelfahrt_2023.pdf)
so it should be included as public holiday.
 