### PR TITLE
Fixed Easter related holidays for Serbia

### DIFF
--- a/src/PublicHoliday/SerbianPublicHoliday.cs
+++ b/src/PublicHoliday/SerbianPublicHoliday.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace PublicHoliday
 {
@@ -70,7 +69,7 @@ namespace PublicHoliday
         /// <returns>Date of in the given year.</returns>
         public static DateTime GoodFriday(int year)
         {
-            var hol = HolidayCalculator.GetEaster(year);
+            var hol = HolidayCalculator.GetOrthodoxEaster(year);
             hol = hol.AddDays(-2);
             return hol;
         }
@@ -87,7 +86,7 @@ namespace PublicHoliday
         /// <returns>Date of in the given year.</returns>
         public static DateTime Easter(int year)
         {
-            return HolidayCalculator.GetEaster(year);
+            return HolidayCalculator.GetOrthodoxEaster(year);
         }
 
         /// <summary>
@@ -97,7 +96,7 @@ namespace PublicHoliday
         /// <returns>Date of in the given year.</returns>
         public static DateTime EasterMonday(int year)
         {
-            var hol = HolidayCalculator.GetEaster(year);
+            var hol = HolidayCalculator.GetOrthodoxEaster(year);
             hol = hol.AddDays(1);
             return hol;
         }
@@ -170,21 +169,31 @@ namespace PublicHoliday
         /// <returns></returns>
         public override IDictionary<DateTime, string> PublicHolidayNames(int year)
         {
-            var easter = HolidayCalculator.GetEaster(year);
-            return new Dictionary<DateTime, string>
+            var easter = HolidayCalculator.GetOrthodoxEaster(year);
+            var dict = new Dictionary<DateTime, string>
             {
                 {NewYearFirst(year), "Нова година"},
                 {NewYearSecond(year), "Нова година"},
                 {Christmas(year), "Божић"},
                 {NationalDayFirst(year), "Дан државности Србије"},
-                {NationalDaySecond(year), "Дан државности Србије"},
-                {GoodFriday(easter), "Велики петак"},
-                {easter, "Васкрс"},
-                {EasterMonday(easter), "Васкрсни понедељак"},
+                {NationalDaySecond(year), "Дан државности Србије"},           
                 {LabourDayFirst(year), "Празник рада"},
                 {LabourDaySecond(year), "Празник рада"},
                 {ArmisticeDay(year), "Дан примирја"}
             };
+            if (!dict.ContainsKey(GoodFriday(year)))
+            {
+                dict.Add(GoodFriday(year), "Велики петак");
+            }
+            if (!dict.ContainsKey(easter))
+            {
+                dict.Add(easter, "Васкрс");
+            }
+            if (!dict.ContainsKey(EasterMonday(year)))
+            {
+                dict.Add(EasterMonday(year), "Васкрсни понедељак");
+            }
+            return dict;
         }
 
         /// <summary>
@@ -208,10 +217,11 @@ namespace PublicHoliday
                     if (NationalDayFirst(year) == date || NationalDaySecond(year) == date) return true;
                     break;
                 case 3:
-                case 4:
+                case 4:               
                     if (EasterMonday(year) == date || Easter(year) == date || GoodFriday(year) == date) return true;
                     break;
                 case 5:
+                    if (EasterMonday(year) == date || Easter(year) == date || GoodFriday(year) == date) return true;                  
                     if (LabourDayFirst(year) == date || LabourDaySecond(year) == date) return true;
                     break;
                 case 11:

--- a/tests/PublicHolidayTests/TestSerbianPublicHoliday.cs
+++ b/tests/PublicHolidayTests/TestSerbianPublicHoliday.cs
@@ -10,7 +10,7 @@ namespace PublicHolidayTests
         [TestMethod]
         public void TestPublicHolidays()
         {
-            var easterMonday = new DateTime(2015, 4, 6);
+            var easterMonday = new DateTime(2015, 4, 13);
             var result = new SerbianPublicHoliday().PublicHolidayNames(2015);
             Assert.AreEqual(11, result.Count);
             Assert.IsTrue(result.ContainsKey(easterMonday));
@@ -19,7 +19,7 @@ namespace PublicHolidayTests
         [TestMethod]
         public void TestIsPublicHoliday()
         {
-            var isPublicHoliday = new SerbianPublicHoliday().IsPublicHoliday(new DateTime(2006, 4, 17));
+            var isPublicHoliday = new SerbianPublicHoliday().IsPublicHoliday(new DateTime(2006, 4, 24));
             Assert.IsTrue(isPublicHoliday, "Easter Monday");
         }
 
@@ -82,7 +82,7 @@ namespace PublicHolidayTests
         [TestMethod]
         public void TestGoodFriday2015()
         {
-            var expected = new DateTime(2015, 4, 3);
+            var expected = new DateTime(2015, 4, 10);
             var actual = SerbianPublicHoliday.GoodFriday(2015);
             Assert.AreEqual(expected, actual);
         }
@@ -90,7 +90,7 @@ namespace PublicHolidayTests
         [TestMethod]
         public void TestEaster2015()
         {
-            var expected = new DateTime(2015, 4, 5);
+            var expected = new DateTime(2015, 4, 12);
             var actual = SerbianPublicHoliday.Easter(2015);
             Assert.AreEqual(expected, actual);
         }
@@ -98,7 +98,7 @@ namespace PublicHolidayTests
         [TestMethod]
         public void TestEaster2024()
         {
-            var expected = new DateTime(2024, 3, 31);
+            var expected = new DateTime(2024, 5, 5);
             var actual = SerbianPublicHoliday.Easter(2024);
             Assert.AreEqual(expected, actual);
             Assert.IsTrue(new SerbianPublicHoliday().IsPublicHoliday(expected));
@@ -107,7 +107,7 @@ namespace PublicHolidayTests
         [TestMethod]
         public void TestEasterMonday2015()
         {
-            var expected = new DateTime(2015, 4, 6);
+            var expected = new DateTime(2015, 4, 13);
             var actual = SerbianPublicHoliday.EasterMonday(2015);
             Assert.AreEqual(expected, actual);
         }
@@ -141,7 +141,6 @@ namespace PublicHolidayTests
             {
                 //looking for collisions
                 var holNames = holidayCalendar.PublicHolidayNames(year);
-                var hols = holidayCalendar.PublicHolidays(year);
                 foreach (var holiday in holNames.Keys)
                 {
                     Assert.IsTrue(holidayCalendar.IsPublicHoliday(holiday),


### PR DESCRIPTION
Easter holidays and related tests were corrected for Serbia - Easter is Orthodox in Serbia.