### PR TITLE
South Africa - Special holiday - 2023 Rugby World Cup Win

### DIFF
--- a/src/PublicHoliday/SouthAfricaPublicHoliday.cs
+++ b/src/PublicHoliday/SouthAfricaPublicHoliday.cs
@@ -272,6 +272,8 @@ namespace PublicHoliday
                         return true;
                     if (BoxingDay(year) == date)
                         return true;
+                    if (date == new DateTime(2023, 12, 15)) //Rugby world cup win public holiday
+                        return true;
                     break;
             }
 

--- a/tests/PublicHolidayTests/TestSouthAfricaPublicHoliday.cs
+++ b/tests/PublicHolidayTests/TestSouthAfricaPublicHoliday.cs
@@ -130,6 +130,7 @@ namespace PublicHolidayTests
         [DataRow(6, 16, "Youth Day")]
         [DataRow(8, 9, "National Women's Day")]
         [DataRow(9, 25, "Heritage Day - Observed on Monday")]
+        [DataRow(12, 15, "Rugby World Cup Win Public Holiday")]
         [DataRow(12, 16, "Day of reconciliation")]
         [DataRow(12, 25, "Christmas")]
         [DataRow(12, 26, "Boxing day")]


### PR DESCRIPTION
See presidential announcement for special holiday:
[President Ramaphosa declares 15 December a public holiday](https://www.sanews.gov.za/south-africa/president-ramaphosa-declares-15-december-public-holiday)