### PR TITLE
Fixed Japanese Equinox Day calculation

### DIFF
--- a/src/PublicHoliday/JapanPublicHoliday.cs
+++ b/src/PublicHoliday/JapanPublicHoliday.cs
@@ -54,11 +54,29 @@ namespace PublicHoliday
         /// <param name="year">The year.</param>
         public static DateTime VernalEquinoxDay(int year)
         {
-            //variations taken from https://en.wikipedia.org/wiki/Autumnal_Equinox_Day
-            if (year == 2014 || year == 2015 || year == 2018 || year == 2019)
+            // Calculation algorithm (Japanese): https://ja.wikipedia.org/wiki/春分の日#1900年から2299年までの春分日
+
+            var yearModuloFour = year % 4;
+
+            if (year >= 1960 && year <= 1991)
             {
-                return new DateTime(year, 3, 21);
+                return yearModuloFour == 0
+                    ? new DateTime(year, 3, 20)
+                    : new DateTime(year, 3, 21);
             }
+            if (year >= 1992 && year <= 2023)
+            {
+                return yearModuloFour == 0 || yearModuloFour == 1
+                    ? new DateTime(year, 3, 20)
+                    : new DateTime(year, 3, 21);
+            }
+            if (year >= 2024 && year <= 2055)
+            {
+                return yearModuloFour == 3
+                    ? new DateTime(year, 3, 21)
+                    : new DateTime(year, 3, 20);
+            }
+
             return FixSunday(new DateTime(year, 3, 20));
         }
 
@@ -147,8 +165,27 @@ namespace PublicHoliday
         /// <returns></returns>
         public static DateTime AutumnalEquinoxDay(int year)
         {
-            //Around September 22 or 23
-            if (year == 2016) return new DateTime(year, 9, 22);
+            // Calculation algorithm (Japanese): https://ja.wikipedia.org/wiki/秋分の日#1900年から2299年までの秋分日
+
+            var yearModuloFour = year % 4;
+
+            if (year >= 1980 && year <= 2011)
+            {
+                return new DateTime(year, 9, 23);
+            }
+            if (year >= 2012 && year <= 2043)
+            {
+                return yearModuloFour == 0
+                    ? new DateTime(year, 9, 22)
+                    : new DateTime(year, 9, 23);
+            }
+            if (year >= 2044 && year <= 2075)
+            {
+                return yearModuloFour == 0 || yearModuloFour == 1
+                    ? new DateTime(year, 9, 22)
+                    : new DateTime(year, 9, 23);
+            }
+
             return FixSunday(new DateTime(year, 9, 23));
         }
 

--- a/tests/PublicHolidayTests/TestJapanPublicHoliday.cs
+++ b/tests/PublicHolidayTests/TestJapanPublicHoliday.cs
@@ -33,6 +33,59 @@ namespace PublicHolidayTests
         }
 
         [TestMethod]
+        public void TestVernalEquinoxDay()
+        {
+            Assert.AreEqual(new DateTime(1980, 3, 20), JapanPublicHoliday.VernalEquinoxDay(1980));
+            Assert.AreEqual(new DateTime(1981, 3, 21), JapanPublicHoliday.VernalEquinoxDay(1981));
+            Assert.AreEqual(new DateTime(1982, 3, 21), JapanPublicHoliday.VernalEquinoxDay(1982));
+            Assert.AreEqual(new DateTime(1983, 3, 21), JapanPublicHoliday.VernalEquinoxDay(1983));
+
+            Assert.AreEqual(new DateTime(2000, 3, 20), JapanPublicHoliday.VernalEquinoxDay(2000));
+            Assert.AreEqual(new DateTime(2001, 3, 20), JapanPublicHoliday.VernalEquinoxDay(2001));
+            Assert.AreEqual(new DateTime(2002, 3, 21), JapanPublicHoliday.VernalEquinoxDay(2002));
+            Assert.AreEqual(new DateTime(2003, 3, 21), JapanPublicHoliday.VernalEquinoxDay(2003));
+
+            Assert.AreEqual(new DateTime(2020, 3, 20), JapanPublicHoliday.VernalEquinoxDay(2020));
+            Assert.AreEqual(new DateTime(2021, 3, 20), JapanPublicHoliday.VernalEquinoxDay(2021));
+            Assert.AreEqual(new DateTime(2022, 3, 21), JapanPublicHoliday.VernalEquinoxDay(2022));
+            Assert.AreEqual(new DateTime(2023, 3, 21), JapanPublicHoliday.VernalEquinoxDay(2023));
+
+            Assert.AreEqual(new DateTime(2024, 3, 20), JapanPublicHoliday.VernalEquinoxDay(2024));
+            Assert.AreEqual(new DateTime(2025, 3, 20), JapanPublicHoliday.VernalEquinoxDay(2025));
+            Assert.AreEqual(new DateTime(2026, 3, 20), JapanPublicHoliday.VernalEquinoxDay(2026));
+            Assert.AreEqual(new DateTime(2027, 3, 21), JapanPublicHoliday.VernalEquinoxDay(2027));
+        }
+
+        [TestMethod]
+        public void TestAutumnalEquinoxDay()
+        {
+            Assert.AreEqual(new DateTime(1980, 9, 23), JapanPublicHoliday.AutumnalEquinoxDay(1980));
+            Assert.AreEqual(new DateTime(1981, 9, 23), JapanPublicHoliday.AutumnalEquinoxDay(1981));
+            Assert.AreEqual(new DateTime(1982, 9, 23), JapanPublicHoliday.AutumnalEquinoxDay(1982));
+            Assert.AreEqual(new DateTime(1983, 9, 23), JapanPublicHoliday.AutumnalEquinoxDay(1983));
+
+            Assert.AreEqual(new DateTime(2000, 9, 23), JapanPublicHoliday.AutumnalEquinoxDay(2000));
+            Assert.AreEqual(new DateTime(2001, 9, 23), JapanPublicHoliday.AutumnalEquinoxDay(2001));
+            Assert.AreEqual(new DateTime(2002, 9, 23), JapanPublicHoliday.AutumnalEquinoxDay(2002));
+            Assert.AreEqual(new DateTime(2003, 9, 23), JapanPublicHoliday.AutumnalEquinoxDay(2003));
+
+            Assert.AreEqual(new DateTime(2020, 9, 22), JapanPublicHoliday.AutumnalEquinoxDay(2020));
+            Assert.AreEqual(new DateTime(2021, 9, 23), JapanPublicHoliday.AutumnalEquinoxDay(2021));
+            Assert.AreEqual(new DateTime(2022, 9, 23), JapanPublicHoliday.AutumnalEquinoxDay(2022));
+            Assert.AreEqual(new DateTime(2023, 9, 23), JapanPublicHoliday.AutumnalEquinoxDay(2023));
+
+            Assert.AreEqual(new DateTime(2024, 9, 22), JapanPublicHoliday.AutumnalEquinoxDay(2024));
+            Assert.AreEqual(new DateTime(2025, 9, 23), JapanPublicHoliday.AutumnalEquinoxDay(2025));
+            Assert.AreEqual(new DateTime(2026, 9, 23), JapanPublicHoliday.AutumnalEquinoxDay(2026));
+            Assert.AreEqual(new DateTime(2027, 9, 23), JapanPublicHoliday.AutumnalEquinoxDay(2027));
+
+            Assert.AreEqual(new DateTime(2044, 9, 22), JapanPublicHoliday.AutumnalEquinoxDay(2044));
+            Assert.AreEqual(new DateTime(2045, 9, 22), JapanPublicHoliday.AutumnalEquinoxDay(2045));
+            Assert.AreEqual(new DateTime(2046, 9, 23), JapanPublicHoliday.AutumnalEquinoxDay(2046));
+            Assert.AreEqual(new DateTime(2047, 9, 23), JapanPublicHoliday.AutumnalEquinoxDay(2047));
+        }
+
+        [TestMethod]
         public void TestHolidaysLists()
         {
             for (int year = 2017; year < 2035; year++)


### PR DESCRIPTION
There was an algorithm to calculate Vernal and Autumnal Equinox Days for Japanese calendar. Although specific days for these holidays are announced every year by the government, it has never announced a different date.