### PR TITLE
Added holidays for Brazil

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ There are libraries for:
   - Canada : CanadaQuebecGovClosingDay (Government province of Quebec closing day)
   - USA : USAPublicHoliday
   - USA : USAFederalReserveHoliday
+- S America
+  - Brazil : BrazilPublicHoliday
 - Oceania
   - Australia : AustraliaPublicHoliday (set State property for regional holidays, see note below)
   - New Zealand : NewZealandPublicHoliday

--- a/src/PublicHoliday/BrazilPublicHoliday.cs
+++ b/src/PublicHoliday/BrazilPublicHoliday.cs
@@ -168,10 +168,9 @@ namespace PublicHoliday
                     return DiaDosFinados(dt.Year) == dt || DiaDaRepublica(dt.Year) == dt;
                 case 12:
                     return Natal(dt.Year) == dt;
-                default:
-                    return false;
             }
-            return PublicHolidays(dt.Year).Contains(dt);
+
+            return false;
         }
         /// <summary>
         /// Public holiday names in Portuguese.

--- a/src/PublicHoliday/BrazilPublicHoliday.cs
+++ b/src/PublicHoliday/BrazilPublicHoliday.cs
@@ -1,0 +1,177 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace PublicHoliday
+{
+    public class BrazilPublicHoliday : PublicHolidayBase
+    {
+        /// <summary>
+        /// New Year's Day (Ano Novo) - January 1st
+        /// </summary>
+        /// <param name="year"></param>
+        /// <returns></returns>
+        public static DateTime AnoNovo(int year)
+        {
+            return new DateTime(year, 1, 1);
+        }
+        /// <summary>
+        /// Carnival(Carnaval) - Even though carnaval takes 5 days. Brazil national holidays for carnival are monday and tuesday.
+        /// </summary>
+        /// <param name="year"></param>
+        /// <returns></returns>
+        public static DateTime CarnavalDayOne(int year)
+        {
+            return HolidayCalculator.GetEaster(year).AddDays(-48);
+        }
+        /// <summary>
+        /// Carnival(Carnaval) - Even though carnaval takes 5 days. Brazil national holidays for carnival are monday and tuesday.
+        /// </summary>
+        /// <param name="year"></param>
+        /// <returns></returns>
+        public static DateTime CarnavalDayTwo(int year)
+        {
+            return HolidayCalculator.GetEaster(year).AddDays(-47);
+        }
+        /// <summary>
+        /// Good Friday(Sexta-feira Santa) - Date varies(the Friday before Easter Sunday, observed by Christians)
+        /// </summary>
+        /// <param name="year"></param>
+        /// <returns></returns>
+        public static DateTime SextaFeiraSanta(int year)
+        {
+            return HolidayCalculator.GetFirstFridayBeforeDate(HolidayCalculator.GetEaster(year));
+        }
+        /// <summary>
+        /// Tiradentes Day(Dia de Tiradentes) - April 21st(commemorating the execution of Joaquim José da Silva Xavier, a leading figure in the Brazilian independence movement)
+        /// </summary>
+        /// <param name="year"></param>
+        /// <returns></returns>
+        public static DateTime Tiradentes(int year)
+        {
+            return new DateTime(year, 4, 21);
+        }
+        /// <summary>
+        /// Labor Day(Dia do Trabalho) - May 1st
+        /// </summary>
+        /// <param name="year"></param>
+        /// <returns></returns>
+        public static DateTime DiaDoTrabalho(int year)
+        {
+            return new DateTime(year, 5, 1);
+        }
+        /// <summary>
+        /// Corpus Christi - Date varies(celebrated on the Thursday after Trinity Sunday, honoring the Eucharist)
+        /// </summary>
+        /// <param name="year"></param>
+        /// <returns></returns>
+        public static DateTime CorpusChristi(int year)
+        {
+            // Calculate the date of Trinity Sunday (8 weeks after Easter)
+            DateTime trinitySunday = HolidayCalculator.GetEaster(year).AddDays(56);
+
+            // Find the Thursday after Trinity Sunday
+            DateTime corpusChristiDate = trinitySunday.AddDays((int)DayOfWeek.Thursday - (int)trinitySunday.DayOfWeek);
+
+            return corpusChristiDate;
+        }
+        /// <summary>
+        /// Independence Day(Dia da Independência) - September 7th(commemorating Brazil's declaration of independence from Portugal in 1822)
+        /// </summary>
+        /// <param name="year"></param>
+        /// <returns></returns>
+        public static DateTime DiaDaIndependencia(int year)
+        {
+            return new DateTime(year, 9, 7);
+        }
+        /// <summary>
+        /// Our Lady of Aparecida Day (Dia de Nossa Senhora Aparecida) - October 12th(honoring Brazil's patron saint, Our Lady of Aparecida)
+        /// </summary>
+        /// <param name="year"></param>
+        /// <returns></returns>
+        public static DateTime NossaSenhoraAparecida(int year)
+        {
+            return new DateTime(year, 10, 12);
+        }
+        /// <summary>
+        /// All Souls' Day (Dia de Finados) - November 2nd (a day to honor and remember the deceased)
+        /// </summary>
+        /// <param name="year"></param>
+        /// <returns></returns>
+        public static DateTime DiaDosFinados(int year)
+        {
+            return new DateTime(year, 11, 2);
+        }
+        /// <summary>
+        /// Republic Day (Dia da República) - November 15th(commemorating the establishment of the Brazilian republic in 1889)
+        /// </summary>
+        /// <param name="year"></param>
+        /// <returns></returns>
+        public static DateTime DiaDaRepublica(int year)
+        {
+            return new DateTime(year, 11, 15);
+        }
+        /// <summary>
+        /// Christmas Day(Natal) - December 25th
+        /// </summary>
+        /// <param name="year"></param>
+        /// <returns></returns>
+        public static DateTime Natal(int year)
+        {
+            return new DateTime(year, 12, 25);
+        }
+        /// <summary>
+        /// Check if a specific date is a public holiday.
+        /// </summary>
+        /// <param name="dt"></param>
+        /// <returns></returns>
+        public override bool IsPublicHoliday(DateTime dt)
+        {
+            return PublicHolidays(dt.Year).Contains(dt);
+        }
+        /// <summary>
+        /// Public holiday names in Portuguese.
+        /// </summary>
+        /// <param name="year"></param>
+        /// <returns></returns>
+        public override IDictionary<DateTime, string> PublicHolidayNames(int year)
+        {
+            return new Dictionary<DateTime, string>() {
+                { AnoNovo(year), "Ano Novo" },
+                { CarnavalDayOne(year), "Carnaval" },
+                { CarnavalDayTwo(year), "Carnaval Terça-Feira Gorda" },
+                { SextaFeiraSanta(year), "Sexta Feira Santa" },
+                { Tiradentes(year), "Dia de Tiradentes" },
+                { DiaDoTrabalho(year), "Dia do Trabalho" },
+                { CorpusChristi(year), "Corpus Christi" },
+                { DiaDaIndependencia(year), "Dia da Independência" },
+                { NossaSenhoraAparecida(year), "Nossa Senhora Aparecida" },
+                { DiaDosFinados(year), "Dia dos Finados" },
+                { DiaDaRepublica(year), "Dia da República" },
+                { Natal(year), "Natal" },
+            };
+        }
+        /// <summary>
+        /// Get a list of dates for all holidays in a year.
+        /// </summary>
+        /// <param name="year"></param>
+        /// <returns></returns>
+        public override IList<DateTime> PublicHolidays(int year)
+        {
+            return new List<DateTime>
+            {
+                AnoNovo(year),
+                CarnavalDayOne(year),
+                CarnavalDayTwo(year),
+                SextaFeiraSanta(year),
+                Tiradentes(year),
+                DiaDoTrabalho(year),
+                CorpusChristi(year),
+                DiaDaIndependencia(year),
+                NossaSenhoraAparecida(year),
+                DiaDosFinados(year),
+                DiaDaRepublica(year),
+                Natal(year),
+            };
+        }
+    }
+}

--- a/src/PublicHoliday/BrazilPublicHoliday.cs
+++ b/src/PublicHoliday/BrazilPublicHoliday.cs
@@ -126,6 +126,51 @@ namespace PublicHoliday
         /// <returns></returns>
         public override bool IsPublicHoliday(DateTime dt)
         {
+            switch (dt.Month)
+            {
+                case 1:
+                    return AnoNovo(dt.Year) == dt;
+                case 2:
+                    if (dt.DayOfWeek == DayOfWeek.Monday)
+                    {
+                        return CarnavalDayOne(dt.Year) == dt;
+                    }
+                    else if (dt.DayOfWeek == DayOfWeek.Tuesday)
+                    {
+                        return CarnavalDayTwo(dt.Year) == dt;
+                    }
+                    break;
+                case 3:
+                    if (dt.DayOfWeek == DayOfWeek.Monday)
+                    {
+                        return CarnavalDayOne(dt.Year) == dt;
+                    }
+                    else if (dt.DayOfWeek == DayOfWeek.Tuesday)
+                    {
+                        return CarnavalDayTwo(dt.Year) == dt;
+                    }
+                    else if (dt.DayOfWeek == DayOfWeek.Friday)
+                    {
+                        return SextaFeiraSanta(dt.Year) == dt;
+                    }
+                    break;
+                case 4:
+                    return ((dt.DayOfWeek == DayOfWeek.Friday) && (SextaFeiraSanta(dt.Year) == dt)) || Tiradentes(dt.Year) == dt;
+                case 5:
+                    return DiaDoTrabalho(dt.Year) == dt || ((dt.DayOfWeek == DayOfWeek.Thursday) && (CorpusChristi(dt.Year) == dt));
+                case 6:
+                    return ((dt.DayOfWeek == DayOfWeek.Thursday) && (CorpusChristi(dt.Year) == dt));
+                case 9:
+                    return DiaDaIndependencia(dt.Year) == dt;
+                case 10:
+                    return NossaSenhoraAparecida(dt.Year) == dt;
+                case 11:
+                    return DiaDosFinados(dt.Year) == dt || DiaDaRepublica(dt.Year) == dt;
+                case 12:
+                    return Natal(dt.Year) == dt;
+                default:
+                    return false;
+            }
             return PublicHolidays(dt.Year).Contains(dt);
         }
         /// <summary>

--- a/src/PublicHoliday/HolidayCalculator.cs
+++ b/src/PublicHoliday/HolidayCalculator.cs
@@ -176,6 +176,16 @@ namespace PublicHoliday
         {
             return FindOccurrenceOfDayOfWeek(hol, DayOfWeek.Monday, 1);
         }
+        public static DateTime GetFirstFridayBeforeDate(DateTime date)
+        {
+            // Calculate the difference in days between the target day (Friday) and the current day of the week
+            int daysToSubtract = ((int)date.DayOfWeek - (int)DayOfWeek.Friday + 7) % 7;
+
+            // Subtract the calculated number of days from the input date
+            DateTime resultDate = date.AddDays(-daysToSubtract);
+
+            return resultDate;
+        }
 
         public static DateTime FindPrevious(DateTime hol, DayOfWeek day)
         {

--- a/tests/PublicHolidayTests/TestBrazilPublicHoliday.cs
+++ b/tests/PublicHolidayTests/TestBrazilPublicHoliday.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PublicHoliday;
+using System;
+
+namespace PublicHolidayTests
+{
+    [TestClass]
+    public class TestBrazilPublicHoliday
+    {
+        [DataTestMethod]
+        [DataRow(1, 1)]
+        [DataRow(2, 12)]
+        [DataRow(2, 13)]
+        [DataRow(3, 29)]
+        [DataRow(4, 21)]
+        [DataRow(5, 1)]
+        [DataRow(5, 30)]
+        [DataRow(9, 7)]
+        [DataRow(10, 12)]
+        [DataRow(11, 2)]
+        [DataRow(11, 15)]
+        [DataRow(12, 25)]
+        public void TestHolidays2017(int month, int day)
+        {
+            var holiday = new DateTime(2024, month, day);
+            var holidayCalendar = new BrazilPublicHoliday();
+            var actual = holidayCalendar.IsPublicHoliday(holiday);
+            Assert.IsTrue(actual, $"{holiday.ToString("D")} is not a holiday");
+        }
+
+        [TestMethod]
+        public void TestHolidays2017Lists()
+        {
+            var holidayCalendar = new BrazilPublicHoliday();
+            var hols = holidayCalendar.PublicHolidays(2024);
+            var holNames = holidayCalendar.PublicHolidayNames(2024);
+            Assert.IsTrue(12 == hols.Count, "Should be 12 holidays in 2024");
+            Assert.IsTrue(holNames.Count == hols.Count, "Names and holiday list are same");
+        }
+    }
+}

--- a/tests/PublicHolidayTests/TestBrazilPublicHoliday.cs
+++ b/tests/PublicHolidayTests/TestBrazilPublicHoliday.cs
@@ -20,7 +20,7 @@ namespace PublicHolidayTests
         [DataRow(11, 2)]
         [DataRow(11, 15)]
         [DataRow(12, 25)]
-        public void TestHolidays2017(int month, int day)
+        public void TestHolidays2024(int month, int day)
         {
             var holiday = new DateTime(2024, month, day);
             var holidayCalendar = new BrazilPublicHoliday();
@@ -28,8 +28,29 @@ namespace PublicHolidayTests
             Assert.IsTrue(actual, $"{holiday.ToString("D")} is not a holiday");
         }
 
+        [DataTestMethod]
+        [DataRow(1, 1)]
+        [DataRow(3, 3)]
+        [DataRow(3, 4)]
+        [DataRow(4, 18)]
+        [DataRow(4, 21)]
+        [DataRow(5, 1)]
+        [DataRow(6, 19)]
+        [DataRow(9, 7)]
+        [DataRow(10, 12)]
+        [DataRow(11, 2)]
+        [DataRow(11, 15)]
+        [DataRow(12, 25)]
+        public void TestHolidays2025(int month, int day)
+        {
+            var holiday = new DateTime(2025, month, day);
+            var holidayCalendar = new BrazilPublicHoliday();
+            var actual = holidayCalendar.IsPublicHoliday(holiday);
+            Assert.IsTrue(actual, $"{holiday.ToString("D")} is not a holiday");
+        }
+
         [TestMethod]
-        public void TestHolidays2017Lists()
+        public void TestHolidays2024Lists()
         {
             var holidayCalendar = new BrazilPublicHoliday();
             var hols = holidayCalendar.PublicHolidays(2024);


### PR DESCRIPTION
Added holidays for Brazil. 

The calendar holidays for Brazil 2024:

1/1/24 | segunda-feira | Confraternização Universal
-- | -- | --
12/2/24 | segunda-feira | Carnaval
13/2/24 | terça-feira | Carnaval
29/3/24 | sexta-feira | Paixão de Cristo
21/4/24 | domingo | Tiradentes
1/5/24 | quarta-feira | Dia do Trabalho
30/5/24 | quinta-feira | Corpus Christi
7/9/24 | sábado | Independência do Brasil
12/10/24 | sábado | Nossa Sr.a Aparecida - Padroeira do Brasil
2/11/24 | sábado | Finados
15/11/24 | sexta-feira | Proclamação da República
25/12/24 | quarta-feira | Natal

and 2025

1/1/25 | quarta-feira | Confraternização Universal
-- | -- | --
3/3/25 | segunda-feira | Carnaval
4/3/25 | terça-feira | Carnaval
18/4/25 | sexta-feira | Paixão de Cristo
21/4/25 | segunda-feira | Tiradentes
1/5/25 | quinta-feira | Dia do Trabalho
19/6/25 | quinta-feira | Corpus Christi
7/9/25 | domingo | Independência do Brasil
12/10/25 | domingo | Nossa Sr.a Aparecida - Padroeira do Brasil
2/11/25 | domingo | Finados
15/11/25 | sábado | Proclamação da República
25/12/25 | quinta-feira | Natal
