### PR TITLE
NYSE holidays

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ There are libraries for:
   - Canada : CanadaQuebecGovClosingDay (Government province of Quebec closing day)
   - USA : USAPublicHoliday
   - USA : USAFederalReserveHoliday
+  - USA : USANewYorkStockExchangeHoliday
 - S America
   - Brazil : BrazilPublicHoliday
 - Oceania

--- a/src/PublicHoliday/USANewYorkStockExchangeHoliday.cs
+++ b/src/PublicHoliday/USANewYorkStockExchangeHoliday.cs
@@ -1,0 +1,280 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace PublicHoliday
+{
+    /// <summary>
+    /// Similar to Federal Holidays in the US
+    /// If a holiday falls on a Saturday it is celebrated the preceding Friday;
+    /// if a holiday falls on a Sunday it is celebrated the following Monday.
+    /// https://www.nyse.com/markets/hours-calendars
+    /// Note that this may not be historically accurate prior to 2022. 
+    /// This only captures what the current holiday set is and may not reflect historical holidays.
+    /// </summary>
+    /// <remarks>
+    /// Recommendation to use cache with UseCachingHolidays for performance 
+    /// </remarks>
+    public class USANewYorkStockExchangeHoliday : PublicHolidayBase
+    {
+
+        #region Individual Holidays
+
+        /// <summary>
+        /// New Years Day. Note in 1999 and 2005 it was 31st December
+        /// </summary>
+        /// <param name="year">The year.</param>
+        /// <returns></returns>
+        public static Holiday NewYear(int year)
+        {
+            var holiday = new DateTime(year, 1, 1);
+            return new Holiday(holiday, HolidayCalculator.FixWeekendSaturdayBeforeSundayAfter(holiday), "NewYear");
+        }
+
+        /// <summary>
+        /// Third Monday in January
+        /// </summary>
+        /// <param name="year">The year.</param>
+        /// <returns></returns>
+        public static Holiday MartinLutherKing(int year)
+        {
+            var hol = new DateTime(year, 1, 15);
+            hol = HolidayCalculator.FindFirstMonday(hol);
+            return new Holiday(hol, hol, "MartinLutherKing");
+        }
+
+        /// <summary>
+        /// Washington's Birthday aka Presidents Day. Third Monday in February
+        /// </summary>
+        /// <param name="year">The year.</param>
+        /// <returns></returns>
+        public static Holiday PresidentsDay(int year)
+        {
+            var hol = new DateTime(year, 2, 15);
+            hol = HolidayCalculator.FindFirstMonday(hol);
+            return new Holiday(hol, hol, "PresidentsDay");
+        }
+
+        /// <summary>
+        /// Good Friday (Friday before Easter) Viernes Santo
+        /// </summary>
+        /// <param name="year"></param>
+        /// <returns></returns>
+        public static Holiday GoodFriday(int year)
+        {
+            DateTime hol = HolidayCalculator.GetEaster(year);
+            hol = hol.AddDays(-2);
+            return new Holiday(hol, hol, "GoodFriday");
+        }
+
+        /// <summary>
+        /// Last Monday in May
+        /// </summary>
+        /// <param name="year">The year.</param>
+        /// <returns></returns>
+        public static Holiday MemorialDay(int year)
+        {
+            var hol = new DateTime(year, 5, 25);
+            hol = HolidayCalculator.FindFirstMonday(hol);
+            return new Holiday(hol, hol, "MemorialDay");
+        }
+
+        /// <summary>
+        /// 19th June
+        /// </summary>
+        /// <param name="year">The year.</param>
+        /// <returns></returns>
+        public static Holiday Juneteenth(int year)
+        {
+            var hol = new DateTime(year, 6, 19);
+            var observed = HolidayCalculator.FixWeekendSaturdayBeforeSundayAfter(hol);
+            return new Holiday(hol, observed, "Juneteenth");
+        }
+
+        /// <summary>
+        /// Independence Day
+        /// </summary>
+        /// <param name="year">The year.</param>
+        /// <returns></returns>
+        public static Holiday IndependenceDay(int year)
+        {
+            var hol = new DateTime(year, 7, 4);
+            var observed = HolidayCalculator.FixWeekendSaturdayBeforeSundayAfter(hol);
+            return new Holiday(hol, observed, "IndependenceDay");
+        }
+
+        /// <summary>
+        /// First Monday in September
+        /// </summary>
+        /// <param name="year">The year.</param>
+        /// <returns></returns>
+        public static Holiday LaborDay(int year)
+        {
+            var hol = new DateTime(year, 9, 1);
+            hol = HolidayCalculator.FindFirstMonday(hol);
+            return new Holiday(hol, hol, "LaborDay");
+        }
+
+        /// <summary>
+        /// Thanksgiving - Fourth Thursday in November
+        /// </summary>
+        /// <param name="year">The year.</param>
+        /// <returns></returns>
+        public static Holiday Thanksgiving(int year)
+        {
+            var hol = new DateTime(year, 11, 22);
+            hol = HolidayCalculator.FindOccurrenceOfDayOfWeek(hol, DayOfWeek.Thursday, 1);
+            return new Holiday(hol, hol, "Thanksgiving");
+        }
+
+        /// <summary>
+        /// Christmas Day
+        /// </summary>
+        /// <param name="year">The year.</param>
+        /// <returns></returns>
+        public static Holiday Christmas(int year)
+        {
+            var hol = new DateTime(year, 12, 25);
+            return new Holiday(hol, HolidayCalculator.FixWeekendSaturdayBeforeSundayAfter(hol), "Christmas");
+        }
+        #endregion
+
+        /// <summary>
+        /// Get a list of dates for all holidays in a year.
+        /// </summary>
+        /// <param name="year">The year.</param>
+        /// <returns></returns>
+        public override IList<DateTime> PublicHolidays(int year)
+        {
+            var bHols = new List<DateTime>();
+
+            foreach (Holiday localholiday in PublicHolidaysInformation(year))
+            {
+                bHols.Add(localholiday);
+
+            }
+
+            return bHols;
+        }
+
+        /// <summary>
+        /// Gets a list of public holidays with their observed and actual date
+        /// </summary>
+        /// <param name="year">The given year</param>
+        /// <returns></returns>
+        public override IList<Holiday> PublicHolidaysInformation(int year)
+        {
+
+#if NETSTANDARD1_3_OR_GREATER || NET40_OR_GREATER
+            if (UseCachingHolidays)
+            {
+                return _cacheHolidays.GetOrAdd(year, y =>
+                {
+                    return PublicHolidaysComplete(year);
+                });
+            }
+#endif
+
+            return PublicHolidaysComplete(year);
+
+        }
+
+        /// <summary>
+        /// Gets a list of public holidays with their observed and actual date
+        /// </summary>
+        /// <param name="year">The given year</param>
+        /// <returns></returns>
+        private IList<Holiday> PublicHolidaysComplete(int year)
+        {
+            var bHols = new List<Holiday>();
+            bHols.Add(NewYear(year)); //1st January
+            bHols.Add(MartinLutherKing(year)); // Third Monday in January
+            bHols.Add(PresidentsDay(year)); //Third Monday in February
+            bHols.Add(GoodFriday(year)); //Friday before Easter
+            bHols.Add(MemorialDay(year)); //Last Monday in May
+            if (year >= 2022)
+            {
+                bHols.Add(Juneteenth(year)); //19th June, from 2022
+            }
+            bHols.Add(IndependenceDay(year)); //4 July
+            bHols.Add(LaborDay(year)); //First Monday in September
+            bHols.Add(Thanksgiving(year)); //Fourth Thursday in November
+            bHols.Add(Christmas(year)); //25 December
+
+            return bHols;
+        }
+
+        /// <summary>
+        /// Get a list of dates with names for all holidays in a year.
+        /// </summary>
+        /// <param name="year">The year.</param>
+        /// <returns></returns>
+        public override IDictionary<DateTime, string> PublicHolidayNames(int year)
+        {
+            var bHols = new Dictionary<DateTime, string>();
+
+            foreach (Holiday localholiday in PublicHolidaysInformation(year))
+            {
+                bHols.Add(localholiday, localholiday.GetName());
+
+            }
+
+            return bHols;
+        }
+        /// <summary>
+        /// Check if a specific date is a federal holiday.
+        /// Obviously the PublicHoliday list is more efficient for repeated checks
+        /// </summary>
+        /// <param name="dt">The date you wish to check</param>
+        /// <returns>True if date is a federal holiday (excluding weekends)</returns>
+        public override bool IsPublicHoliday(DateTime dt)
+        {
+            int year = dt.Year;
+            var date = dt.Date;
+
+            switch (dt.Month)
+            {
+                case 1:
+                    if (NewYear(year) == date)
+                        return true;
+                    if (MartinLutherKing(year) == date)
+                        return true;
+                    break;
+                case 2:
+                    if (PresidentsDay(year) == date)
+                        return true;
+                    break;
+                case 4:
+                    if (GoodFriday(year) == date)
+                        return true;
+                    break;
+                case 5:
+                    if (MemorialDay(year) == date)
+                        return true;
+                    break;
+                case 6:
+                    if (year >= 2022 && Juneteenth(year) == date)
+                        return true;
+                    break;
+                case 7:
+                    if (IndependenceDay(year) == date)
+                        return true;
+                    break;
+                case 9:
+                    if (LaborDay(year) == date)
+                        return true;
+                    break;
+                case 11:
+                    if (Thanksgiving(year) == date)
+                        return true;
+                    break;
+                case 12:
+                    if (Christmas(year) == date)
+                        return true;
+                    if (NewYear(year + 1) == date)
+                        return true; //31st December if New Year is Saturday
+                    break;
+            }
+            return false;
+        }
+    }
+}

--- a/tests/PublicHolidayTests/TestUSNewYorkStockExchangeHoliday.cs
+++ b/tests/PublicHolidayTests/TestUSNewYorkStockExchangeHoliday.cs
@@ -1,0 +1,232 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PublicHoliday;
+using System;
+using System.Linq;
+
+namespace PublicHolidayTests
+{
+    /// <summary>
+    /// Using official calendar from http://www.opm.gov/fedhol/2006.asp
+    /// </summary>
+    [TestClass]
+    public class TestNewYorkStockExchangeHoliday
+    {
+        [TestMethod]
+        public void TestThanksgiving2018()
+        {
+            var expected = new DateTime(2018, 11, 22);
+            var actual = USANewYorkStockExchangeHoliday.Thanksgiving(2018);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void TestNewYear2004()
+        {
+            var expected = new DateTime(2004, 1, 1);
+            var actual = USANewYorkStockExchangeHoliday.NewYear(2004);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void TestMartinLutherKing2004()
+        {
+            var expected = new DateTime(2004, 1, 19);
+            var actual = USANewYorkStockExchangeHoliday.MartinLutherKing(2004);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void TestWashington2004()
+        {
+            var expected = new DateTime(2004, 2, 16);
+            var actual = USANewYorkStockExchangeHoliday.PresidentsDay(2004);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void TestGoodFriday2006()
+        {
+            var goodFriday = USANewYorkStockExchangeHoliday.GoodFriday(2006);
+            Assert.AreEqual(new DateTime(2006, 4, 14), goodFriday);
+        }
+
+        [TestMethod]
+        public void TestMemorial2004()
+        {
+            var expected = new DateTime(2004, 5, 31);
+            var actual = USANewYorkStockExchangeHoliday.MemorialDay(2004);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void TestIndependence2004()
+        {
+            var expected = new DateTime(2004, 7, 5);
+            var actual = USANewYorkStockExchangeHoliday.IndependenceDay(2004);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void TestLabor2004()
+        {
+            var expected = new DateTime(2004, 9, 6);
+            var actual = USANewYorkStockExchangeHoliday.LaborDay(2004);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void TestThanksgiving2004()
+        {
+            var expected = new DateTime(2004, 11, 25);
+            var actual = USANewYorkStockExchangeHoliday.Thanksgiving(2004);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void TestChristmas2004()
+        {
+            var expected = new DateTime(2004, 12, 24);
+            var actual = USANewYorkStockExchangeHoliday.Christmas(2004);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void TestNewYear()
+        {
+            var expected = new DateTime(2006, 1, 2);
+            var actual = USANewYorkStockExchangeHoliday.NewYear(2006);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void TestNewYearObservedVsActual()
+        {
+            var actual = USANewYorkStockExchangeHoliday.NewYear(2023);
+            Assert.AreEqual(new DateTime(2023, 1, 2), actual.ObservedDate, "1st January is Sunday, so observed on Monday");
+            Assert.AreEqual(new DateTime(2023, 1, 1), actual.HolidayDate, "1st January is Sunday, available on Holiday date");
+            Assert.AreEqual(new DateTime(2023, 1, 2), actual, "Implicit conversion to observed date");
+            var hols = new USANewYorkStockExchangeHoliday().PublicHolidaysInformation(2023);
+            var newYear = hols.First();
+            Assert.AreEqual(new DateTime(2023, 1, 2), newYear.ObservedDate, "1st January is Sunday, so observed on Monday");
+            Assert.AreEqual(new DateTime(2023, 1, 1), newYear.HolidayDate, "1st January is Sunday, available on Holiday date");
+        }
+
+        [TestMethod]
+        public void TestMartinLutherKingDay()
+        {
+            var expected = new DateTime(2006, 1, 16);
+            var actual = USANewYorkStockExchangeHoliday.MartinLutherKing(2006);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void TestWashington()
+        {
+            var expected = new DateTime(2006, 2, 20);
+            var actual = USANewYorkStockExchangeHoliday.PresidentsDay(2006);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void TestMemorial()
+        {
+            var expected = new DateTime(2006, 5, 29);
+            var actual = USANewYorkStockExchangeHoliday.MemorialDay(2006);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void TestIndependence()
+        {
+            var expected = new DateTime(2006, 7, 4);
+            var actual = USANewYorkStockExchangeHoliday.IndependenceDay(2006);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void TestLabor()
+        {
+            var expected = new DateTime(2006, 9, 4);
+            var actual = USANewYorkStockExchangeHoliday.LaborDay(2006);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void TestThanksgiving()
+        {
+            var expected = new DateTime(2006, 11, 23);
+            var actual = USANewYorkStockExchangeHoliday.Thanksgiving(2006);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void TestChristmas()
+        {
+            var expected = new DateTime(2006, 12, 25);
+            var actual = USANewYorkStockExchangeHoliday.Christmas(2006);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void TestThanksgiving1999()
+        {
+            var expected = new DateTime(1999, 11, 25);
+            var actual = USANewYorkStockExchangeHoliday.Thanksgiving(1999);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void TestIsPublicHoliday()
+        {
+            var thanksgiving = new DateTime(1999, 11, 25);
+            var result = new USANewYorkStockExchangeHoliday().IsPublicHoliday(thanksgiving);
+            Assert.IsTrue(result);
+        }
+
+        [TestMethod]
+        public void TestNextWorkingDay()
+        {
+            var thanksgiving = new DateTime(1999, 11, 25);
+            var result = new USANewYorkStockExchangeHoliday().NextWorkingDay(thanksgiving);
+            Assert.AreEqual(new DateTime(1999, 11, 26), result);
+        }
+
+        [TestMethod]
+        public void TestJuneteenth2022()
+        {
+            var holidayDate = new DateTime(2022, 6, 19);
+            var result = USANewYorkStockExchangeHoliday.Juneteenth(2022);
+            var observedDate = new DateTime(2022, 6, 20);
+            Assert.AreEqual(holidayDate, result.HolidayDate);
+            Assert.AreEqual(observedDate, result.ObservedDate);
+
+            //Was made a holiday for NYSE in 2022, so it should not appear in 2021 list
+            holidayDate = holidayDate.AddYears(-1);
+            var nyseHolidays = new USANewYorkStockExchangeHoliday().PublicHolidaysInformation(2021);
+            var isJuneteenthPrior2022 = nyseHolidays.Where(x => x.HolidayDate == holidayDate).Any();
+            Assert.IsFalse(isJuneteenthPrior2022);
+        }
+
+        [TestMethod]
+        public void TestPublicHolidays()
+        {
+            var thanksgiving = new DateTime(1999, 11, 25);
+            var result = new USANewYorkStockExchangeHoliday().PublicHolidays(1999);
+            Assert.AreEqual(9, result.Count);
+            Assert.IsTrue(result.Contains(thanksgiving));
+        }
+
+        [TestMethod]
+        public void TestPublicHolidayInformation()
+        {
+            var USANewYorkStockExchangeHoliday = new USANewYorkStockExchangeHoliday();
+            var hols = USANewYorkStockExchangeHoliday.PublicHolidays(2017);
+            var infos = USANewYorkStockExchangeHoliday.PublicHolidaysInformation(2017);
+            Assert.AreEqual(hols.Count, infos.Count);
+            foreach (var info in infos)
+            {
+                Assert.IsTrue(hols.Contains(info), "observed date is implicitly in both lists");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Copied holidays from US Public Holidays
Removed Veterans and Columbus days
Added Good Friday
Slight modification to Juneteenth since it was not observed by NYSE until 2022 instead of 2021.
Added similar unit tests
Update to README to reflect new holiday set