### PR TITLE
South Africa 2024 Election day

### DIFF
--- a/src/PublicHoliday/SouthAfricaPublicHoliday.cs
+++ b/src/PublicHoliday/SouthAfricaPublicHoliday.cs
@@ -201,6 +201,10 @@ namespace PublicHoliday
             {
                 bHols.Add(new DateTime(2023, 12, 15), "Rugby World Cup celebration");
             }
+            if (year == 2024)
+            {
+                bHols.Add(new DateTime(2024, 05, 29), "Election day");
+            }
             bHols.Add(Christmas(year), "Christmas Day");
             bHols.Add(BoxingDay(year), "Day of Goodwill");
             return bHols;
@@ -245,6 +249,8 @@ namespace PublicHoliday
 
                 case 5:
                     if (LabourDay(year) == date)
+                        return true;
+                    if (date == new DateTime(2024, 05, 29)) //Election day 2024
                         return true;
                     break;
 

--- a/tests/PublicHolidayTests/TestSouthAfricaPublicHoliday.cs
+++ b/tests/PublicHolidayTests/TestSouthAfricaPublicHoliday.cs
@@ -149,6 +149,7 @@ namespace PublicHolidayTests
         [DataRow(4, 1, "Family Day")]
         [DataRow(4, 27, "Freedom Day")]
         [DataRow(5, 1, "Workers' Day")]
+        [DataRow(5, 29, "Election Day")]
         [DataRow(6, 17, "Youth Day - Observed on Monday")]
         [DataRow(8, 9, "National Women's Day")]
         [DataRow(9, 24, "Heritage Day")]


### PR DESCRIPTION
May 29th 2024 (South African election day), proclaimed a public holiday

[https://www.thepresidency.gov.za/president-proclaims-election-date-and-public-holiday](https://www.thepresidency.gov.za/president-proclaims-election-date-and-public-holiday)