### PR TITLE
Address issue #141 with Japan dates in 2025

### DIFF
--- a/src/PublicHoliday/JapanPublicHoliday.cs
+++ b/src/PublicHoliday/JapanPublicHoliday.cs
@@ -21,7 +21,7 @@ namespace PublicHoliday
         public static DateTime NewYear(int year)
         {
             var hol = new DateTime(year, 1, 1);
-            hol = FixSunday(hol);
+            hol = FixSunday(hol, HolidayName.NewYear);
             return hol;
         }
 
@@ -45,7 +45,7 @@ namespace PublicHoliday
         public static DateTime FoundationDay(int year)
         {
             //Feb 11
-            return FixSunday(new DateTime(year, 2, 11));
+            return FixSunday(new DateTime(year, 2, 11), HolidayName.FoundationDay);
         }
 
         /// <summary>
@@ -83,7 +83,7 @@ namespace PublicHoliday
                 vernalEquinoxDay = new DateTime(year, 3, 20);
             }
 
-            return FixSunday(vernalEquinoxDay);
+            return FixSunday(vernalEquinoxDay, HolidayName.NewYear);
         }
 
         /// <summary>
@@ -95,7 +95,7 @@ namespace PublicHoliday
         {
             // using the ō character would causes compilation errors on some system
             //29 April
-            return FixSunday(new DateTime(year, 4, 29));
+            return FixSunday(new DateTime(year, 4, 29), HolidayName.FoundationDay);
         }
 
         /// <summary>
@@ -106,7 +106,7 @@ namespace PublicHoliday
         public static DateTime ConstitutionMemorialDay(int year)
         {
             //3 May
-            return FixSunday(new DateTime(year, 5, 3));
+            return FixSunday(new DateTime(year, 5, 3), HolidayName.ConstitutionMemorialDay);
         }
 
         /// <summary>
@@ -117,7 +117,7 @@ namespace PublicHoliday
         public static DateTime GreeneryDay(int year)
         {
             //4 May
-            return FixSunday(new DateTime(year, 5, 4));
+            return FixSunday(new DateTime(year, 5, 4), HolidayName.GreeneryDay);
         }
 
         /// <summary>
@@ -128,7 +128,7 @@ namespace PublicHoliday
         public static DateTime ChildrensDay(int year)
         {
             //5 May
-            return FixSunday(new DateTime(year, 5, 5));
+            return FixSunday(new DateTime(year, 5, 5), HolidayName.ChildrensDay);
         }
 
         /// <summary>
@@ -151,7 +151,7 @@ namespace PublicHoliday
         {
             if (year < 2016) return null;
             //11 August, from 2016 onwards
-            return FixSunday(new DateTime(year, 8, 11));
+            return FixSunday(new DateTime(year, 8, 11), HolidayName.MountainDay);
         }
 
         /// <summary>
@@ -199,7 +199,7 @@ namespace PublicHoliday
                 autumnalEquinoxDay = new DateTime(year, 9, 23);
             }
 
-            return FixSunday(autumnalEquinoxDay);
+            return FixSunday(autumnalEquinoxDay, HolidayName.AutumnalEquinoxDay);
         }
 
         /// <summary>
@@ -221,7 +221,7 @@ namespace PublicHoliday
         public static DateTime CultureDay(int year)
         {
             //November 3
-            return FixSunday(new DateTime(year, 11, 3));
+            return FixSunday(new DateTime(year, 11, 3), HolidayName.CultureDay);
         }
 
         /// <summary>
@@ -232,7 +232,7 @@ namespace PublicHoliday
         public static DateTime LabourThanksgivingDay(int year)
         {
             //November 23
-            return FixSunday(new DateTime(year, 11, 23));
+            return FixSunday(new DateTime(year, 11, 23), HolidayName.LabourThanksgivingDay);
         }
 
         /// <summary>
@@ -245,19 +245,40 @@ namespace PublicHoliday
             if (year >= 2020)
             {
                 //23 February Emperor Naruhito 徳仁 2020 – 	 
-                return FixSunday(new DateTime(year, 2, 23));
+                return FixSunday(new DateTime(year, 2, 23), HolidayName.EmperorsBirthday);
             }
             //23 December Emperor Akihito 明仁 1989–2018
-            return FixSunday(new DateTime(year, 12, 23));
+            return FixSunday(new DateTime(year, 12, 23), HolidayName.EmperorsBirthday);
         }
 
-        private static DateTime FixSunday(DateTime hol)
+        private static DateTime FixSunday(DateTime hol, HolidayName holidayName)
         {
             if (hol.DayOfWeek == DayOfWeek.Sunday)
+            {
                 hol = hol.AddDays(1);
+            }
+
+            if (holidayName == HolidayName.GreeneryDay && hol == ChildrensDay(hol.Year))
+            {
+                hol = hol.AddDays(1);
+            }
+
             return hol;
         }
 
+        private enum HolidayName
+        {
+            AutumnalEquinoxDay,
+            ChildrensDay,
+            ConstitutionMemorialDay,
+            CultureDay,
+            EmperorsBirthday,
+            FoundationDay,
+            GreeneryDay,
+            LabourThanksgivingDay,
+            MountainDay,
+            NewYear,
+        }
         #endregion Individual Holidays
 
         /// <summary>

--- a/src/PublicHoliday/PublicHoliday.csproj
+++ b/src/PublicHoliday/PublicHoliday.csproj
@@ -22,42 +22,44 @@
 2.5.0: US 2021 Juneteenth added
 2.6.0: New Zealand Matariki dates added for next 30 years
 2.7.0: Add Denmark (thanks @Halling69), add Canada Truth&amp;Reconciliation from 2021 (thanks @mattandwhatnot), change Japan Emperors Day (thanks @zimathon)
-2.8.0: Add Canada Governement Quebec Closing Day , improve HolidayCalculator (thanks @Hrothval)
-2.9.0: Add Localized String for class Holiday, Adding cache for Easter for performance framework 4.0+/andard1.3+ (thanks @Hrothval) Added RomanianPublicHoliday (thanks @mihaigliga21)
-2.10.0: Add in HolidayCalculator PreviousWorkingDay/NextWorkingDay with x open day, Add eCachingHolidays with default to false in IPublicHolidays/PublicHolidayBase, Add in IsWorkingDay in ublicHolidays, Add target .NET 5.0 (thanks @Hrothval)
-2.11.0: Add Estonia (thanks @Kaupo) Add USAFederalReserveHoliday (thanks @AndrewPecha). Add calizationString for France and US. Adjust framework for code section, CanadaQuebecGovClosingDay djustholiday name for past year CanadaDay and NationalPatriotDay, HolidayCalculator reviousWorkingDay/extWorkingDay option ignore same day, IPublicHolidays/PublicHolidayBase add eviousWorkingDayNotSameDay and NextWorkingDayNotSameDay, USAPublicHoliday add holiday name and andardization (thanks @Hrothval)
-2.12.0: Fix DutchPublicHoliday LiberationDay (thanks @sergiu05)
-2.13.0: Fix ANZAC/Easter Monday conflict (thanks @seancallinan )
-2.14.0: #66 Add holiday names for USAFederalReserveHoliday
-2.15.0: #67 Fix spelling Switzerland Pfingsten
-2.16.0 #69 Add Lithuania (thanks @aursad)
-2.16.2 #72 Add state funeral of Queen Elizabeth II, UK, Canada, Australia, New Zealand (thanks eancallinan )
-2.17.0 #73 NZ provincial holidays added (thanks @seancallinan ) #74 Germany holiday error
-2.18.0 #77 South african public holidays fixes (thanks @FifoTheHein ) #78 Added polish diacritics thanks@konradbartecki )
-2.19.0 #79 Added Turkey (thanks @HakanUcaar )
-2.20.0 Added UK special holiday for Coronation, 2023
-2.21.0 #81 Added Slovenian holidays (thanks @KlemenS189 )
-2.22.0: #82 South Africa Christmas dates moved (thanks @ FifoTheHein )
-2.23.0: #83 Add Finland holidays (thanks @vergi40 )
-2.24.0: Ireland adds St Brigid's day from 2023
-2.25.0: Australia + New Zealand- King's Birthday added (Queen's Birthday retained for backwards API mpatibility/historic dates), Denmark remove General Prayer Day from 2024 (thanks @Jesper Nysteen)
-2.26.0: Add Greece holidays
-2.27.0: Fix issues with Turkey Holidays (thanks @ahmet-cetinkaya )
-2.28.0: #94 #96 Conditional holidays in Denmark (day after Ascension) and Netherlands (Liberation Day tionally only in Lustrum years) -Thanks @SeanSEmerson, @swannet)
-2.29.0: Womans Day in Mecklenburg-Vorpommern since 2023, added Serbian holidays (thanks @Reo1980, lekseiKrasilnikov)
-2.30.0: #102 Add Montenegro holidays (thanks @anovik); add netstandard2.1 target, no other changes
-2.31.0: #103 Add missing holidays for Brandenburg (thanks @Cryma); #104 Germany: Assumption in Bavaria hanks @mkrso )
-2.32.0: #107 Serbia orthodox easter (thanks @anovik); #108 UK boxing day rules (thanks @spetsen)
-2.33.0: #113 #112 Ireland holidays fix weekend rules (thanks @Bjornsen016)
-2.34.0: #114 South Africa - Special holiday - 2023 Rugby World Cup Win (thanks @FifoTheHein)
-2.35.0: #115 Fixed Japanese Equinox Day calculation (thanks @Makaopior )
-2.36.0: #116 Fixed Japanese Vernal and Autumnal Equinox days (thanks @Makaopior )
-2.37.0: #120 Add Brazil holidays (thanks @rsegecin ), Netherlands add Good Friday (thanks @wdnijdam  )
-2.38.0: #122 Update Switzerland Holiday with Cantons (thanks @tossnet), Add NYSE holidays  (thanks @stephenherrick )
-2.39.0: #125 Fix Turkey Ramadan and FeastOfSacrifices holidays (thanks @hasankaplan-github), #128 Update Switzerland Holiday (thanks @tossnet),; #131 Update France holiday with overseas territories (thanks @tossnet); #132 Add Portugal Holiday (thanks @greybird); #133 South Africa 2024 election day (thanks @FifoTheHein)
-2.40.0: #135 Bavarian Assumption date is conditional
-2.41.0: #136 Denmark additional optional holidays (thanks @hanshb)
-3.0.0: #138 Remove Japanese character from method name due to MsBuild error- breaking change (thanks @vilinet @wollac11 ); #139 add business days calculations</PackageReleaseNotes>
+      2.8.0: Add Canada Governement Quebec Closing Day , improve HolidayCalculator (thanks @Hrothval)
+      2.9.0: Add Localized String for class Holiday, Adding cache for Easter for performance framework 4.0+/andard1.3+ (thanks @Hrothval) Added RomanianPublicHoliday (thanks @mihaigliga21)
+      2.10.0: Add in HolidayCalculator PreviousWorkingDay/NextWorkingDay with x open day, Add eCachingHolidays with default to false in IPublicHolidays/PublicHolidayBase, Add in IsWorkingDay in ublicHolidays, Add target .NET 5.0 (thanks @Hrothval)
+      2.11.0: Add Estonia (thanks @Kaupo) Add USAFederalReserveHoliday (thanks @AndrewPecha). Add calizationString for France and US. Adjust framework for code section, CanadaQuebecGovClosingDay djustholiday name for past year CanadaDay and NationalPatriotDay, HolidayCalculator reviousWorkingDay/extWorkingDay option ignore same day, IPublicHolidays/PublicHolidayBase add eviousWorkingDayNotSameDay and NextWorkingDayNotSameDay, USAPublicHoliday add holiday name and andardization (thanks @Hrothval)
+      2.12.0: Fix DutchPublicHoliday LiberationDay (thanks @sergiu05)
+      2.13.0: Fix ANZAC/Easter Monday conflict (thanks @seancallinan )
+      2.14.0: #66 Add holiday names for USAFederalReserveHoliday
+      2.15.0: #67 Fix spelling Switzerland Pfingsten
+      2.16.0 #69 Add Lithuania (thanks @aursad)
+      2.16.2 #72 Add state funeral of Queen Elizabeth II, UK, Canada, Australia, New Zealand (thanks eancallinan )
+      2.17.0 #73 NZ provincial holidays added (thanks @seancallinan ) #74 Germany holiday error
+      2.18.0 #77 South african public holidays fixes (thanks @FifoTheHein ) #78 Added polish diacritics thanks@konradbartecki )
+      2.19.0 #79 Added Turkey (thanks @HakanUcaar )
+      2.20.0 Added UK special holiday for Coronation, 2023
+      2.21.0 #81 Added Slovenian holidays (thanks @KlemenS189 )
+      2.22.0: #82 South Africa Christmas dates moved (thanks @ FifoTheHein )
+      2.23.0: #83 Add Finland holidays (thanks @vergi40 )
+      2.24.0: Ireland adds St Brigid's day from 2023
+      2.25.0: Australia + New Zealand- King's Birthday added (Queen's Birthday retained for backwards API mpatibility/historic dates), Denmark remove General Prayer Day from 2024 (thanks @Jesper Nysteen)
+      2.26.0: Add Greece holidays
+      2.27.0: Fix issues with Turkey Holidays (thanks @ahmet-cetinkaya )
+      2.28.0: #94 #96 Conditional holidays in Denmark (day after Ascension) and Netherlands (Liberation Day tionally only in Lustrum years) -Thanks @SeanSEmerson, @swannet)
+      2.29.0: Womans Day in Mecklenburg-Vorpommern since 2023, added Serbian holidays (thanks @Reo1980, lekseiKrasilnikov)
+      2.30.0: #102 Add Montenegro holidays (thanks @anovik); add netstandard2.1 target, no other changes
+      2.31.0: #103 Add missing holidays for Brandenburg (thanks @Cryma); #104 Germany: Assumption in Bavaria hanks @mkrso )
+      2.32.0: #107 Serbia orthodox easter (thanks @anovik); #108 UK boxing day rules (thanks @spetsen)
+      2.33.0: #113 #112 Ireland holidays fix weekend rules (thanks @Bjornsen016)
+      2.34.0: #114 South Africa - Special holiday - 2023 Rugby World Cup Win (thanks @FifoTheHein)
+      2.35.0: #115 Fixed Japanese Equinox Day calculation (thanks @Makaopior )
+      2.36.0: #116 Fixed Japanese Vernal and Autumnal Equinox days (thanks @Makaopior )
+      2.37.0: #120 Add Brazil holidays (thanks @rsegecin ), Netherlands add Good Friday (thanks @wdnijdam  )
+      2.38.0: #122 Update Switzerland Holiday with Cantons (thanks @tossnet), Add NYSE holidays  (thanks @stephenherrick )
+      2.39.0: #125 Fix Turkey Ramadan and FeastOfSacrifices holidays (thanks @hasankaplan-github), #128 Update Switzerland Holiday (thanks @tossnet),; #131 Update France holiday with overseas territories (thanks @tossnet); #132 Add Portugal Holiday (thanks @greybird); #133 South Africa 2024 election day (thanks @FifoTheHein)
+      2.40.0: #135 Bavarian Assumption date is conditional
+      2.41.0: #136 Denmark additional optional holidays (thanks @hanshb)
+      3.0.0: #138 Remove Japanese character from method name due to MsBuild error- breaking change (thanks @vilinet @wollac11 ); #139 add business days calculations
+      3.1.0: #141 Issue with Greeneryday in Japan in 2025
+    </PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/martinjw/Holiday</PackageProjectUrl>
     <PackageLicenseUrl></PackageLicenseUrl>
     <Description>Calculate national public holidays for countries including US, UK, France, Belgium, Germany, Australia, Canada and many others for any year</Description>

--- a/tests/PublicHolidayTests/TestJapanPublicHoliday.cs
+++ b/tests/PublicHolidayTests/TestJapanPublicHoliday.cs
@@ -32,6 +32,31 @@ namespace PublicHolidayTests
             Assert.IsTrue(actual, $"{holiday.ToString("D")} is not a holiday -{name}");
         }
 
+        [DataTestMethod]
+        [DataRow(1, 1, "New year - observed on Monday")]
+        [DataRow(1, 13, "Coming of Age Day")]
+        [DataRow(2, 11, "Foundation Day (Saturday)")]
+        [DataRow(2, 24, "The Emperor's Birthday")]
+        [DataRow(3, 20, "Vernal Equinox Day")]
+        [DataRow(4, 29, "Showa Day")]
+        [DataRow(5, 3, "Constitution Memorial Day")]
+        [DataRow(5, 5, "Children's Day")]
+        [DataRow(5, 6, "Greenery Day")]
+        [DataRow(7, 21, "Marine Day")]
+        [DataRow(8, 11, "Mountain Day")]
+        [DataRow(9, 15, "Respect for the Aged Day")]
+        [DataRow(9, 23, "Autumnal Equinox Day")]
+        [DataRow(10, 13, "Health and Sports Day")]
+        [DataRow(11, 3, "Culture Day")]
+        [DataRow(11, 24, "Labour Thanksgiving Day")]
+        public void TestHolidays2025(int month, int day, string name)
+        {
+	        var holiday = new DateTime(2025, month, day);
+	        var holidayCalendar = new JapanPublicHoliday();
+	        var actual = holidayCalendar.IsPublicHoliday(holiday);
+	        Assert.IsTrue(actual, $"{holiday.ToString("D")} is not a holiday -{name}");
+        }
+
         [TestMethod]
         public void TestVernalEquinoxDay()
         {


### PR DESCRIPTION
This allows for the fact on 2025 that the two Japanese bank holidays fall on the same day in May and one has been moved an extra day 