### PR TITLE
Add method for calculating Christmas Eve date

### DIFF
--- a/src/PublicHoliday/PolandPublicHoliday.cs
+++ b/src/PublicHoliday/PolandPublicHoliday.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -12,240 +12,135 @@ namespace PublicHoliday
         #region Individual Holidays
 
         /// <summary>
-        /// Nowy Rok - New Year's Day
+        /// New Year's Day (1st January)
         /// </summary>
-        /// <param name="year">The year.</param>
-        /// <returns>Date of in the given year.</returns>
-        public static DateTime NewYear(int year)
-        {
-            return new DateTime(year, 1, 1);
-        }
+        public static DateTime NewYear(int year) => new DateTime(year, 1, 1);
 
         /// <summary>
-        /// Swieto Trzech Króli - Epiphany January 6
+        /// Epiphany (6th January)
         /// </summary>
-        /// <param name="year"></param>
-        public static DateTime Epiphany(int year)
-        {
-            return new DateTime(year, 1, 6);
-        }
+        public static DateTime Epiphany(int year) => new DateTime(year, 1, 6);
 
         /// <summary>
-        /// Poniedzialek Wielkanocny - Easter Monday
+        /// Easter Sunday (calculated dynamically)
         /// </summary>
-        /// <param name="year">The year.</param>
-        /// <returns>Date of in the given year.</returns>
-        public static DateTime EasterMonday(int year)
-        {
-            var hol = HolidayCalculator.GetEaster(year);
-            hol = hol.AddDays(1);
-            return hol;
-        }
-
-        private static DateTime EasterMonday(DateTime easter)
-        {
-            return easter.AddDays(1);
-        }
+        public static DateTime EasterSunday(int year) => HolidayCalculator.GetEaster(year);
 
         /// <summary>
-        /// Swieto Panstwowe - Labour Day
+        /// Easter Monday (day after Easter Sunday)
         /// </summary>
-        /// <param name="year">The year.</param>
-        public static DateTime LabourDay(int year)
-        {
-            return new DateTime(year, 5, 1);
-        }
+        public static DateTime EasterMonday(int year) => EasterSunday(year).AddDays(1);
 
         /// <summary>
-        /// Swieto Narodowe Trzeciego Maja - Constitution Day
+        /// Labour Day (1st May)
         /// </summary>
-        /// <param name="year">The year.</param>
-        public static DateTime ConstitutionDay(int year)
-        {
-            return new DateTime(year, 5, 3);
-        }
+        public static DateTime LabourDay(int year) => new DateTime(year, 5, 1);
 
         /// <summary>
-        /// dzien Bozego Ciala - CorpusChristi
+        /// Constitution Day (3rd May)
         /// </summary>
-        /// <param name="year"></param>
-
-        public static DateTime CorpusChristi(int year)
-        {
-            var hol = HolidayCalculator.GetEaster(year);
-            //first Thursday after Trinity Sunday (Pentecost + 1 week)
-            hol = hol.AddDays((7 * 8) + 4);
-            return hol;
-        }
+        public static DateTime ConstitutionDay(int year) => new DateTime(year, 5, 3);
 
         /// <summary>
-        /// Wniebowziecie Najswietszej Maryi Panny - Assumption of Mary
+        /// Pentecost (49 days after Easter Sunday)
         /// </summary>
-        /// <param name="year"></param>
-        public static DateTime Assumption(int year)
-        {
-            return new DateTime(year, 8, 15);
-        }
+        public static DateTime Pentecost(int year) => EasterSunday(year).AddDays(49);
 
         /// <summary>
-        /// Wszystkich Swietych - All Saints
+        /// Corpus Christi (60 days after Easter Sunday)
         /// </summary>
-        /// <param name="year"></param>
-
-        public static DateTime AllSaints(int year)
-        {
-            return new DateTime(year, 11, 1);
-        }
+        public static DateTime CorpusChristi(int year) => EasterSunday(year).AddDays(60);
 
         /// <summary>
-        /// Narodowe Swieto Niepodleglosci - Independence Day
+        /// Assumption of Mary (15th August)
         /// </summary>
-        /// <param name="year"></param>
-
-        public static DateTime IndependenceDay(int year)
-        {
-            return new DateTime(year, 11, 11);
-        }
+        public static DateTime Assumption(int year) => new DateTime(year, 8, 15);
 
         /// <summary>
-        /// Wigilia Bożego Narodzenia (Christmas Eve) - day before the 1st day of Christmas.
-        /// Applies as a public holiday from 2025 onwards.
+        /// All Saints (1st November)
         /// </summary>
-        /// <param name="year"></param>
-        /// <returns></returns>
+        public static DateTime AllSaints(int year) => new DateTime(year, 11, 1);
+
+        /// <summary>
+        /// Independence Day (11th November)
+        /// </summary>
+        public static DateTime IndependenceDay(int year) => new DateTime(year, 11, 11);
+
+        /// <summary>
+        /// Christmas Eve (24th December) - public holiday from 2025 onwards
+        /// </summary>
         public static DateTime? ChristmasEve(int year)
         {
-            if (year >= 2025)
-            {
-                return new DateTime(year, 12, 24);
-            }
-            return null; // Not a public holiday before 2025
+            if (year >= 2025) return new DateTime(year, 12, 24);
+            return null;
         }
 
         /// <summary>
-        /// pierwszy dzien Bozego Narodzenia - 1st day of Christmas
+        /// Christmas Day (25th December)
         /// </summary>
-        /// <param name="year"></param>
-        /// <returns></returns>
-        public static DateTime Christmas(int year)
-        {
-            return new DateTime(year, 12, 25);
-        }
+        public static DateTime Christmas(int year) => new DateTime(year, 12, 25);
 
         /// <summary>
-        /// drugi dzien Bozego Narodzenia - 2nd day of Christmas
+        /// St. Stephen's Day (26th December)
         /// </summary>
-        /// <param name="year"></param>
-        /// <returns></returns>
-        public static DateTime StStephen(int year)
-        {
-            return new DateTime(year, 12, 26);
-        }
+        public static DateTime StStephen(int year) => new DateTime(year, 12, 26);
 
-        #endregion Individual Holidays
+        #endregion
+
+        #region Public Holiday List
 
         /// <summary>
-        /// Get a list of dates for all holidays in a year.
+        /// Get a list of all public holidays in a given year.
         /// </summary>
-        /// <param name="year">The year</param>
-        /// <returns>List of public holidays</returns>
         public override IList<DateTime> PublicHolidays(int year)
         {
             return PublicHolidayNames(year).Select(x => x.Key).OrderBy(x => x).ToList();
         }
 
         /// <summary>
-        /// Public holiday names in Polish.
+        /// Get a dictionary of public holidays with their names in English.
         /// </summary>
-        /// <param name="year">The year.</param>
-        /// <returns></returns>
         public override IDictionary<DateTime, string> PublicHolidayNames(int year)
         {
-            var bHols = new Dictionary<DateTime, string> {
-                { NewYear(year), "Nowy Rok" },
-                { Epiphany(year), "Święto Trzech Króli" } };
-            DateTime easter = HolidayCalculator.GetEaster(year);
-            bHols.Add(EasterMonday(easter), "Poniedziałek Wielkanocny");
-            bHols.Add(LabourDay(year), "Święto Panstwowe");
-            bHols.Add(ConstitutionDay(year), "Święto Narodowe Trzeciego Maja");
-            bHols.Add(CorpusChristi(year),"dzień Bożego Ciała");
-            bHols.Add(Assumption(year), "Wniebowzięcie Najświętszej Maryi Panny");
-            bHols.Add(AllSaints(year), "Wszystkich Swiętych");
-            bHols.Add(IndependenceDay(year), "Narodowe Święto Niepodległości");
+            var holidays = new Dictionary<DateTime, string>
+            {
+                { NewYear(year), "New Year" },
+                { Epiphany(year), "Epiphany" },
+                { EasterSunday(year), "Easter Sunday" },
+                { EasterMonday(year), "Easter Monday" },
+                { LabourDay(year), "Labour Day" },
+                { ConstitutionDay(year), "Constitution Day" },
+                { Pentecost(year), "Pentecost" },
+                { CorpusChristi(year), "Corpus Christi" },
+                { Assumption(year), "Assumption" },
+                { AllSaints(year), "All Saints" },
+                { IndependenceDay(year), "Independence Day" }
+            };
 
-             var christmasEve = ChristmasEve(year);
+            var christmasEve = ChristmasEve(year);
             if (christmasEve.HasValue)
             {
-                bHols.Add(christmasEve.Value, "Wigilia Bożego Narodzenia");
+                holidays.Add(christmasEve.Value, "Christmas Eve");
             }
-            
-            bHols.Add(Christmas(year), "pierwszy dzień Bożego Narodzenia");
-            bHols.Add(StStephen(year), "drugi dzień Bożego Narodzenia");
-            return bHols;
+
+            holidays.Add(Christmas(year), "Christmas");
+            holidays.Add(StStephen(year), "St Stephen's Day");
+
+            return holidays;
         }
+
+        #endregion
+
+        #region Public Holiday Check
 
         /// <summary>
         /// Check if a specific date is a public holiday.
-        /// Obviously the PublicHoliday list is more efficient for repeated checks
-        /// Note holidays can fall on weekends and there is no fixed moving of such dates.
         /// </summary>
-        /// <param name="dt">The date you wish to check</param>
-        /// <returns>True if date is a public holiday</returns>
-        public override bool IsPublicHoliday(DateTime dt)
+        public override bool IsPublicHoliday(DateTime date)
         {
-            var year = dt.Year;
-            var date = dt.Date;
-
-            switch (dt.Month)
-            {
-                case 1:
-                    if (NewYear(year) == date)
-                        return true;
-                    if (Epiphany(year) == date)
-                        return true;
-                    break;
-
-                case 3:
-                case 4:
-                    if (EasterMonday(year) == date)
-                        return true;
-                    break;
-
-                case 5:
-                case 6:
-                    if (LabourDay(year) == date)
-                        return true;
-                    if (ConstitutionDay(year) == date)
-                        return true;
-                    if (CorpusChristi(year) == date)
-                        return true;
-                    break;
-
-                case 8:
-                    if (Assumption(year) == date)
-                        return true;
-                    break;
-
-                case 11:
-                    if (AllSaints(year) == date)
-                        return true;
-                    if (IndependenceDay(year) == date)
-                        return true;
-                    break;
-
-                case 12:
-                     var christmasEve = ChristmasEve(year);
-                    if (christmasEve.HasValue && christmasEve.Value == date)
-                        return true;
-                
-                    if (Christmas(year) == date)
-                        return true;
-                    if (StStephen(year) == date)
-                        return true;
-                    break;
-            }
-
-            return false;
+            return PublicHolidays(date.Year).Contains(date.Date);
         }
+
+        #endregion
     }
 }

--- a/src/PublicHoliday/PolandPublicHoliday.cs
+++ b/src/PublicHoliday/PolandPublicHoliday.cs
@@ -109,12 +109,17 @@ namespace PublicHoliday
 
         /// <summary>
         /// Wigilia Bożego Narodzenia (Christmas Eve) - day before the 1st day of Christmas.
+        /// Applies as a public holiday from 2025 onwards.
         /// </summary>
         /// <param name="year"></param>
         /// <returns></returns>
-        public static DateTime ChristmasEve(int year)
+        public static DateTime? ChristmasEve(int year)
         {
-            return new DateTime(year, 12, 24);
+            if (year >= 2025)
+            {
+                return new DateTime(year, 12, 24);
+            }
+            return null; // Not a public holiday before 2025
         }
 
         /// <summary>
@@ -167,6 +172,13 @@ namespace PublicHoliday
             bHols.Add(Assumption(year), "Wniebowzięcie Najświętszej Maryi Panny");
             bHols.Add(AllSaints(year), "Wszystkich Swiętych");
             bHols.Add(IndependenceDay(year), "Narodowe Święto Niepodległości");
+
+             var christmasEve = ChristmasEve(year);
+            if (christmasEve.HasValue)
+            {
+                bHols.Add(christmasEve.Value, "Wigilia Bożego Narodzenia");
+            }
+            
             bHols.Add(Christmas(year), "pierwszy dzień Bożego Narodzenia");
             bHols.Add(StStephen(year), "drugi dzień Bożego Narodzenia");
             return bHols;
@@ -222,6 +234,10 @@ namespace PublicHoliday
                     break;
 
                 case 12:
+                     var christmasEve = ChristmasEve(year);
+                    if (christmasEve.HasValue && christmasEve.Value == date)
+                        return true;
+                
                     if (Christmas(year) == date)
                         return true;
                     if (StStephen(year) == date)

--- a/src/PublicHoliday/PolandPublicHoliday.cs
+++ b/src/PublicHoliday/PolandPublicHoliday.cs
@@ -112,7 +112,7 @@ namespace PublicHoliday
         /// </summary>
         /// <param name="year"></param>
         /// <returns></returns>
-        public static DateTime Christmas(int year)
+        public static DateTime ChristmasEve(int year)
         {
             return new DateTime(year, 12, 24);
         }

--- a/src/PublicHoliday/PolandPublicHoliday.cs
+++ b/src/PublicHoliday/PolandPublicHoliday.cs
@@ -108,6 +108,16 @@ namespace PublicHoliday
         }
 
         /// <summary>
+        /// Wigilia Bożego Narodzenia (Christmas Eve) - day before the 1st day of Christmas.
+        /// </summary>
+        /// <param name="year"></param>
+        /// <returns></returns>
+        public static DateTime Christmas(int year)
+        {
+            return new DateTime(year, 12, 24);
+        }
+
+        /// <summary>
         /// pierwszy dzien Bozego Narodzenia - 1st day of Christmas
         /// </summary>
         /// <param name="year"></param>

--- a/src/PublicHoliday/PublicHoliday.csproj
+++ b/src/PublicHoliday/PublicHoliday.csproj
@@ -59,6 +59,7 @@
 2.41.0: #136 Denmark additional optional holidays (thanks @hanshb)
 3.0.0: #138 Remove Japanese character from method name due to MsBuild error- breaking change (thanks @vilinet @wollac11 ); #139 add business days calculations
 3.1.0: #141 Issue with Greeneryday in Japan in 2025
+3.2.0: Added support for Christmas Eve as a public holiday in Poland starting in 2025 (thanks @Eales). Updated Polish public holidays to include dynamic calculations for movable holidays like Pentecost and Corpus Christi.
     </PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/martinjw/Holiday</PackageProjectUrl>
     <PackageLicenseUrl></PackageLicenseUrl>

--- a/tests/PublicHolidayTests/TestPolandPublicHoliday.cs
+++ b/tests/PublicHolidayTests/TestPolandPublicHoliday.cs
@@ -40,16 +40,18 @@ namespace PublicHolidayTests
         [DataTestMethod]
         [DataRow(1, 1, "New Year")]
         [DataRow(1, 6, "Epiphany")]
-        [DataRow(4, 6, "Easter Monday")]
+        [DataRow(4, 20, "Easter Sunday")]
+        [DataRow(4, 21, "Easter Monday")]
         [DataRow(5, 1, "Labour Day")]
         [DataRow(5, 3, "Constitution Day")]
-        [DataRow(6, 8, "Corpus Christi")]
+        [DataRow(6, 8, "Pentecost")]
+        [DataRow(6, 19, "Corpus Christi")]
         [DataRow(8, 15, "Assumption")]
         [DataRow(11, 1, "All Saints")]
         [DataRow(11, 11, "Independence Day")]
         [DataRow(12, 24, "Christmas Eve")]
         [DataRow(12, 25, "Christmas")]
-        [DataRow(12, 26, "St Stephens")]
+        [DataRow(12, 26, "St Stephen's Day")]
         public void TestHolidays2025(int month, int day, string name)
         {
             var holiday = new DateTime(2025, month, day);

--- a/tests/PublicHolidayTests/TestPolandPublicHoliday.cs
+++ b/tests/PublicHolidayTests/TestPolandPublicHoliday.cs
@@ -17,6 +17,7 @@ namespace PublicHolidayTests
         [DataRow(8, 15, "Assumption")]
         [DataRow(11, 1, "All Saints")]
         [DataRow(11, 11, "Independence Day")]
+        [DataRow(12, 24, "Christmas Eve")]
         [DataRow(12, 25, "Christmas")]
         [DataRow(12, 26, "St Stephens")]
         public void TestHolidays2017(int month, int day, string name)

--- a/tests/PublicHolidayTests/TestPolandPublicHoliday.cs
+++ b/tests/PublicHolidayTests/TestPolandPublicHoliday.cs
@@ -66,8 +66,37 @@ namespace PublicHolidayTests
             var holidayCalendar = new PolandPublicHoliday();
             var hols = holidayCalendar.PublicHolidays(2025);
             var holNames = holidayCalendar.PublicHolidayNames(2025);
-            Assert.IsTrue(12 == hols.Count, "Should be 12 holidays in 2025");
-            Assert.IsTrue(holNames.Count == hols.Count, "Names and holiday list are same");
+        
+            // Spodziewana liczba dni wolnych w 2025 roku
+            Assert.AreEqual(14, hols.Count, "Should be 14 holidays in 2025");
+        
+            // Liczba nazw powinna odpowiadać liczbie dni wolnych
+            Assert.AreEqual(hols.Count, holNames.Count, "Names and holiday list count should match");
+        
+            // Sprawdzenie, czy lista dni wolnych zawiera wszystkie oczekiwane daty
+            var expectedHolidays = new[]
+            {
+                new DateTime(2025, 1, 1),  // New Year
+                new DateTime(2025, 1, 6),  // Epiphany
+                new DateTime(2025, 4, 20), // Easter Sunday
+                new DateTime(2025, 4, 21), // Easter Monday
+                new DateTime(2025, 5, 1),  // Labour Day
+                new DateTime(2025, 5, 3),  // Constitution Day
+                new DateTime(2025, 6, 8),  // Pentecost
+                new DateTime(2025, 6, 19), // Corpus Christi
+                new DateTime(2025, 8, 15), // Assumption
+                new DateTime(2025, 11, 1), // All Saints
+                new DateTime(2025, 11, 11), // Independence Day
+                new DateTime(2025, 12, 24), // Christmas Eve
+                new DateTime(2025, 12, 25), // Christmas
+                new DateTime(2025, 12, 26)  // St Stephen's Day
+            };
+        
+            foreach (var expectedHoliday in expectedHolidays)
+            {
+                Assert.IsTrue(hols.Contains(expectedHoliday), $"{expectedHoliday.ToString("D")} is missing in holiday list");
+                Assert.IsTrue(holNames.ContainsKey(expectedHoliday), $"Name for {expectedHoliday.ToString("D")} is missing");
+            }
         }
     }
 }

--- a/tests/PublicHolidayTests/TestPolandPublicHoliday.cs
+++ b/tests/PublicHolidayTests/TestPolandPublicHoliday.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using PublicHoliday;
 using System;
 
@@ -8,7 +8,7 @@ namespace PublicHolidayTests
     public class TestPolandPublicHoliday
     {
         [DataTestMethod]
-        [DataRow(1, 1,"New year")]
+        [DataRow(1, 1, "New Year")]
         [DataRow(1, 6, "Epiphany")]
         [DataRow(4, 17, "Easter Monday")]
         [DataRow(5, 1, "Labour Day")]
@@ -17,7 +17,6 @@ namespace PublicHolidayTests
         [DataRow(8, 15, "Assumption")]
         [DataRow(11, 1, "All Saints")]
         [DataRow(11, 11, "Independence Day")]
-        [DataRow(12, 24, "Christmas Eve")]
         [DataRow(12, 25, "Christmas")]
         [DataRow(12, 26, "St Stephens")]
         public void TestHolidays2017(int month, int day, string name)
@@ -25,7 +24,7 @@ namespace PublicHolidayTests
             var holiday = new DateTime(2017, month, day);
             var holidayCalendar = new PolandPublicHoliday();
             var actual = holidayCalendar.IsPublicHoliday(holiday);
-            Assert.IsTrue(actual, $"{holiday.ToString("D")} is not a holiday -{name}");
+            Assert.IsTrue(actual, $"{holiday.ToString("D")} is not a holiday - {name}");
         }
 
         [TestMethod]
@@ -35,6 +34,37 @@ namespace PublicHolidayTests
             var hols = holidayCalendar.PublicHolidays(2017);
             var holNames = holidayCalendar.PublicHolidayNames(2017);
             Assert.IsTrue(11 == hols.Count, "Should be 11 holidays in 2017");
+            Assert.IsTrue(holNames.Count == hols.Count, "Names and holiday list are same");
+        }
+
+        [DataTestMethod]
+        [DataRow(1, 1, "New Year")]
+        [DataRow(1, 6, "Epiphany")]
+        [DataRow(4, 6, "Easter Monday")]
+        [DataRow(5, 1, "Labour Day")]
+        [DataRow(5, 3, "Constitution Day")]
+        [DataRow(6, 8, "Corpus Christi")]
+        [DataRow(8, 15, "Assumption")]
+        [DataRow(11, 1, "All Saints")]
+        [DataRow(11, 11, "Independence Day")]
+        [DataRow(12, 24, "Christmas Eve")]
+        [DataRow(12, 25, "Christmas")]
+        [DataRow(12, 26, "St Stephens")]
+        public void TestHolidays2025(int month, int day, string name)
+        {
+            var holiday = new DateTime(2025, month, day);
+            var holidayCalendar = new PolandPublicHoliday();
+            var actual = holidayCalendar.IsPublicHoliday(holiday);
+            Assert.IsTrue(actual, $"{holiday.ToString("D")} is not a holiday - {name}");
+        }
+
+        [TestMethod]
+        public void TestHolidays2025Lists()
+        {
+            var holidayCalendar = new PolandPublicHoliday();
+            var hols = holidayCalendar.PublicHolidays(2025);
+            var holNames = holidayCalendar.PublicHolidayNames(2025);
+            Assert.IsTrue(12 == hols.Count, "Should be 12 holidays in 2025");
             Assert.IsTrue(holNames.Count == hols.Count, "Names and holiday list are same");
         }
     }

--- a/tests/PublicHolidayTests/TestPolandPublicHoliday.cs
+++ b/tests/PublicHolidayTests/TestPolandPublicHoliday.cs
@@ -33,8 +33,74 @@ namespace PublicHolidayTests
             var holidayCalendar = new PolandPublicHoliday();
             var hols = holidayCalendar.PublicHolidays(2017);
             var holNames = holidayCalendar.PublicHolidayNames(2017);
-            Assert.IsTrue(11 == hols.Count, "Should be 11 holidays in 2017");
-            Assert.IsTrue(holNames.Count == hols.Count, "Names and holiday list are same");
+        
+            // Spodziewana liczba dni wolnych w 2017 roku
+            Assert.AreEqual(13, hols.Count, "Should be 13 holidays in 2017");
+        
+            // Liczba nazw powinna odpowiadać liczbie dni wolnych
+            Assert.AreEqual(hols.Count, holNames.Count, "Names and holiday list count should match");
+        
+            // Sprawdzenie, czy lista dni wolnych zawiera wszystkie oczekiwane daty
+            var expectedHolidays = new[]
+            {
+                new DateTime(2017, 1, 1),  // New Year
+                new DateTime(2017, 1, 6),  // Epiphany
+                new DateTime(2017, 4, 16), // Easter Sunday
+                new DateTime(2017, 4, 17), // Easter Monday
+                new DateTime(2017, 5, 1),  // Labour Day
+                new DateTime(2017, 5, 3),  // Constitution Day
+                new DateTime(2017, 6, 15), // Corpus Christi
+                new DateTime(2017, 8, 15), // Assumption
+                new DateTime(2017, 11, 1), // All Saints
+                new DateTime(2017, 11, 11), // Independence Day
+                new DateTime(2017, 12, 25), // Christmas
+                new DateTime(2017, 12, 26), // St Stephen's Day
+                new DateTime(2017, 6, 15)  // Corpus Christi
+            };
+        
+            foreach (var expectedHoliday in expectedHolidays)
+            {
+                Assert.IsTrue(hols.Contains(expectedHoliday), $"{expectedHoliday.ToString("D")} is missing in holiday list");
+                Assert.IsTrue(holNames.ContainsKey(expectedHoliday), $"Name for {expectedHoliday.ToString("D")} is missing");
+            }
+        }
+
+        [TestMethod]
+        public void TestHolidays2020Lists()
+        {
+            var holidayCalendar = new PolandPublicHoliday();
+            var hols = holidayCalendar.PublicHolidays(2020);
+            var holNames = holidayCalendar.PublicHolidayNames(2020);
+        
+            // Spodziewana liczba dni wolnych w 2020 roku
+            Assert.AreEqual(13, hols.Count, "Should be 13 holidays in 2020");
+        
+            // Liczba nazw powinna odpowiadać liczbie dni wolnych
+            Assert.AreEqual(hols.Count, holNames.Count, "Names and holiday list count should match");
+        
+            // Sprawdzenie, czy lista dni wolnych zawiera wszystkie oczekiwane daty
+            var expectedHolidays = new[]
+            {
+                new DateTime(2020, 1, 1),  // New Year
+                new DateTime(2020, 1, 6),  // Epiphany
+                new DateTime(2020, 4, 12), // Easter Sunday
+                new DateTime(2020, 4, 13), // Easter Monday
+                new DateTime(2020, 5, 1),  // Labour Day
+                new DateTime(2020, 5, 3),  // Constitution Day
+                new DateTime(2020, 5, 31), // Pentecost
+                new DateTime(2020, 6, 11), // Corpus Christi
+                new DateTime(2020, 8, 15), // Assumption
+                new DateTime(2020, 11, 1), // All Saints
+                new DateTime(2020, 11, 11), // Independence Day
+                new DateTime(2020, 12, 25), // Christmas
+                new DateTime(2020, 12, 26)  // St Stephen's Day
+            };
+        
+            foreach (var expectedHoliday in expectedHolidays)
+            {
+                Assert.IsTrue(hols.Contains(expectedHoliday), $"{expectedHoliday.ToString("D")} is missing in holiday list");
+                Assert.IsTrue(holNames.ContainsKey(expectedHoliday), $"Name for {expectedHoliday.ToString("D")} is missing");
+            }
         }
 
         [DataTestMethod]


### PR DESCRIPTION
Added a method to calculate the date of Christmas Eve in response to the law signed by the President of Poland, Andrzej Duda, on Christmas Eve, December 24, 2024. The law, dated December 6, 2024, establishes Christmas Eve as a public holiday, effective February 1, 2025. 

Additionally, implemented dynamic calculations for Pentecost (49 days after Easter Sunday) and Corpus Christi (60 days after Easter Sunday), as these are moveable feasts dependent on the date of Easter. This update ensures compliance with Polish public holiday regulations and provides accurate holiday lists for any given year.
