### PR TITLE
added Berlin state one-time holidays to GermanPublicHoliday

### DIFF
--- a/src/PublicHoliday/GermanPublicHoliday.cs
+++ b/src/PublicHoliday/GermanPublicHoliday.cs
@@ -401,6 +401,40 @@ namespace PublicHoliday
         }
 
         /// <summary>
+        /// Liberation Day/ Tag der Befreiung
+        /// </summary>
+        /// <param name="year"></param>
+        /// <returns></returns>
+        public static DateTime LiberationDay(int year)
+        {
+            return new DateTime(year, 5, 8);
+        }
+
+        /// <summary>
+        /// Whether this state observes Liberation Day/Tag der Befreiung (May 8)
+        /// </summary>
+        /// <param name="year"></param>
+        /// <returns></returns>
+        public bool HasLiberationDay(int year) => (State == States.BE && year == 2025);
+
+        /// <summary>
+        /// East German Uprising Memorial Day / Gedenktag an den Volksaufstand in der DDR
+        /// </summary>
+        /// <param name="year"></param>
+        /// <returns></returns>
+        public static DateTime EastGermanUprisingMemorialDay(int year)
+        {
+            return new DateTime(year, 6, 17);
+        }
+
+        /// <summary>
+        /// Whether this state observes East German Uprising Memorial Day / Gedenktag an den Volksaufstand in der DDR (June 17)
+        /// </summary>
+        /// <param name="year"></param>
+        /// <returns></returns>
+        public bool HasEastGermanUprisingMemorialDay(int year) => (State == States.BE && year == 2028);
+
+        /// <summary>
         /// List of federal and state holidays (for defined <see cref="State"/>)
         /// </summary>
         /// <param name="year">The year.</param>
@@ -427,6 +461,8 @@ namespace PublicHoliday
             if (HasRepentance) bHols.Add(Repentance(year));
             bHols.Add(Christmas(year));
             bHols.Add(StStephen(year));
+            if (HasLiberationDay(year)) bHols.Add(LiberationDay(year));
+            if (HasEastGermanUprisingMemorialDay(year)) bHols.Add(EastGermanUprisingMemorialDay(year));
             return bHols;
         }
 
@@ -446,10 +482,12 @@ namespace PublicHoliday
             if (HasEasterSunday) bHols.Add(EasterSunday(year), "Ostersonntag");
             bHols.Add(EasterMonday(year), "Ostermontag");
             bHols.Add(MayDay(year), "Tag der Arbeit");
+            if (HasLiberationDay(year)) bHols.Add(LiberationDay(year), "Tag der Befreiung");
             bHols.Add(Ascension(year), "Christi Himmelfahrt");
             if (HasPentecostSunday) bHols.Add(PentecostSunday(year), "Pfingstsonntag");
             bHols.Add(PentecostMonday(year), "Pfingstmontag");
             if (HasCorpusChristi) bHols.Add(CorpusChristi(year), "Fronleichnam");
+            if (HasEastGermanUprisingMemorialDay(year)) bHols.Add(EastGermanUprisingMemorialDay(year), "Gedenktag an den Volksaufstand in der DDR");
             if (HasAssumption) bHols.Add(Assumption(year), "Mariä Himmelfahrt");
             if (HasWorldChildrensDay(year)) bHols.Add(WorldChildrensDay(year), "Kindertag");
             bHols.Add(GermanUnity(year), "Tag der Deutschen Einheit");
@@ -505,6 +543,10 @@ namespace PublicHoliday
                     if (PentecostMonday(year) == date)
                         return true;
                     if (HasCorpusChristi && CorpusChristi(year) == date)
+                        return true;
+                    if (HasLiberationDay(year) && LiberationDay(year) == date)
+                        return true;
+                    if (HasEastGermanUprisingMemorialDay(year) && EastGermanUprisingMemorialDay(year) == date)
                         return true;
                     break;
 

--- a/tests/PublicHolidayTests/TestGermanyPublicHoliday.cs
+++ b/tests/PublicHolidayTests/TestGermanyPublicHoliday.cs
@@ -175,5 +175,49 @@ namespace PublicHolidayTests
             Assert.IsFalse(isHoliday);
 
         }
+
+        [TestMethod]
+        public void TestBerlinOneTimeHolidays()
+        {
+            var liberationDay2024 = GermanPublicHoliday.LiberationDay(2024);
+            Assert.AreEqual(new DateTime(2024, 5, 8), liberationDay2024);
+            var liberationDay2025 = GermanPublicHoliday.LiberationDay(2025);
+            Assert.AreEqual(new DateTime(2025, 5, 8), liberationDay2025);
+            var liberationDay2026 = GermanPublicHoliday.LiberationDay(2026);
+            Assert.AreEqual(new DateTime(2026, 5, 8), liberationDay2026);
+
+            var eastGermanUprisingMemorialDay2027 = GermanPublicHoliday.EastGermanUprisingMemorialDay(2027);
+            Assert.AreEqual(new DateTime(2027, 6, 17), eastGermanUprisingMemorialDay2027);
+            var eastGermanUprisingMemorialDay2028 = GermanPublicHoliday.EastGermanUprisingMemorialDay(2028);
+            Assert.AreEqual(new DateTime(2028, 6, 17), eastGermanUprisingMemorialDay2028);
+            var eastGermanUprisingMemorialDay2029 = GermanPublicHoliday.EastGermanUprisingMemorialDay(2029);
+            Assert.AreEqual(new DateTime(2029, 6, 17), eastGermanUprisingMemorialDay2029);
+
+            foreach (GermanPublicHoliday.States germanState in Enum.GetValues(typeof(GermanPublicHoliday.States)))
+            {
+                var stateCalendar = new GermanPublicHoliday { State = germanState };
+
+                if(germanState == GermanPublicHoliday.States.BE)
+                {
+                    Assert.IsFalse(stateCalendar.IsPublicHoliday(liberationDay2024));
+                    Assert.IsTrue(stateCalendar.IsPublicHoliday(liberationDay2025));
+                    Assert.IsFalse(stateCalendar.IsPublicHoliday(liberationDay2026));
+
+                    Assert.IsFalse(stateCalendar.IsPublicHoliday(eastGermanUprisingMemorialDay2027));
+                    Assert.IsTrue(stateCalendar.IsPublicHoliday(eastGermanUprisingMemorialDay2028));
+                    Assert.IsFalse(stateCalendar.IsPublicHoliday(eastGermanUprisingMemorialDay2029));
+                }
+                else
+                {
+                    Assert.IsFalse(stateCalendar.IsPublicHoliday(liberationDay2024));
+                    Assert.IsFalse(stateCalendar.IsPublicHoliday(liberationDay2025));
+                    Assert.IsFalse(stateCalendar.IsPublicHoliday(liberationDay2026));
+
+                    Assert.IsFalse(stateCalendar.IsPublicHoliday(eastGermanUprisingMemorialDay2027));
+                    Assert.IsFalse(stateCalendar.IsPublicHoliday(eastGermanUprisingMemorialDay2028));
+                    Assert.IsFalse(stateCalendar.IsPublicHoliday(eastGermanUprisingMemorialDay2029));
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Adds one-time public holidays for Berlin:
- 8 May 2025 (liberation day)
- 17 June 2028 (commemorating the 1953 East German uprising)

Fixes #146