### PR TITLE
option to add NSW bank holiday to Australian public holidays

### DIFF
--- a/src/PublicHoliday/AustraliaPublicHoliday.cs
+++ b/src/PublicHoliday/AustraliaPublicHoliday.cs
@@ -21,6 +21,12 @@ namespace PublicHoliday
         /// </summary>
         public States State { get; set; }
 
+
+        /// <summary>
+        /// Set this true to include the NSW Bank holiday as a public holiday, 
+        /// </summary>
+        public bool IncludeNSWBankHoliday { get; set; } = false;
+
         /// <summary>
         ///
         /// </summary>
@@ -224,6 +230,17 @@ namespace PublicHoliday
         }
 
         /// <summary>
+        /// Bank Holiday (NSW only), first Monday of August
+        /// </summary>
+        /// <param name="year"></param>
+
+        public static DateTime BankHoliday(int year) {
+            //only Northern Territory
+            return HolidayCalculator.FindNext(new DateTime(year, 8, 1), DayOfWeek.Monday);
+        }
+
+
+        /// <summary>
         /// Family  and community day, Australian Capital Territory.
         /// </summary>
         /// <param name="year">The year.</param>
@@ -389,6 +406,11 @@ namespace PublicHoliday
             {
                 bHols.Add(MelbourneCup(year), "Melbourne Cup");
             }
+            if(State == States.NSW) 
+            {
+                if(IncludeNSWBankHoliday)
+                    bHols.Add(BankHoliday(year), "Bank Holiday");
+            }
             bHols.Add(Christmas(year), "Christmas Day");
             bHols.Add(BoxingDay(year), State == States.SA ? "Proclamation Day" : "Boxing Day");
 
@@ -467,8 +489,13 @@ namespace PublicHoliday
                     break;
 
                 case 8:
+
                     if (State == States.NT && PicnicDay(year) == date)
                         return true;
+
+                    if (State == States.NSW && IncludeNSWBankHoliday && BankHoliday(year) == date)
+                        return true;
+
                     break;
 
                 case 9:

--- a/tests/PublicHolidayTests/TestAustraliaPublicHoliday.cs
+++ b/tests/PublicHolidayTests/TestAustraliaPublicHoliday.cs
@@ -193,5 +193,16 @@ namespace PublicHolidayTests
             var holNames = holidayCalendar.PublicHolidayNames(year);
             Assert.IsTrue(holNames.ContainsKey(kingQueenBirthday));
         }
+
+        [DataTestMethod]
+        [DataRow(2022, 8, 1, "Bank Holiday")] 
+        [DataRow(2024, 8, 5, "Bank Holiday")]
+        public void TestNSWBankHoliday(int year, int month, int day, string name) {
+            var bankHoliday = new DateTime(year, month, day);
+            Assert.AreEqual(bankHoliday, AustraliaPublicHoliday.BankHoliday(year), $"Holiday for {name} {year}"); 
+            var holidayCalendar = new AustraliaPublicHoliday { State = AustraliaPublicHoliday.States.NSW, IncludeNSWBankHoliday = true };
+            var holNames = holidayCalendar.PublicHolidayNames(year);
+            Assert.IsTrue(holNames.ContainsKey(bankHoliday));
+        }
     }
 }


### PR DESCRIPTION
NSW bank holidays are partial public holidays where banking and financial services businesses are closed.

An option to include NSW Bank Holidays as a public holiday when determining Australian public holidays is necessary for our use case and I believe it falls within the scope of this project.

Added a property to AustraliaPublicHoliday.cs

public bool IncludeNSWBankHoliday { get; set; } = false;

This bool defauilts to false so as to not affect existiing implementations of this package. 
When set to true, the output from a new public holiday definition:

public static DateTime BankHoliday(int year)

is added to the PublicHolidayNames andIsPublicHoliday methods
