### PR TITLE
Fix IsBankHoliday method for St Andrews day in Scotland when it falls on a weekend

### DIFF
--- a/src/PublicHoliday/UKBankHoliday.cs
+++ b/src/PublicHoliday/UKBankHoliday.cs
@@ -411,6 +411,8 @@ namespace PublicHoliday
                         return true;
                     if (BoxingDay(year) == date)
                         return true;
+                    if (UkCountry == UkCountries.Scotland && StAndrews(year) == date)
+                        return true;
                     break;
             }
             if ((year == 2002) &&

--- a/tests/PublicHolidayTests/TestUKBankHoliday.cs
+++ b/tests/PublicHolidayTests/TestUKBankHoliday.cs
@@ -363,14 +363,31 @@ namespace PublicHolidayTests
             }
         }
 
+        [TestMethod]
+        public void TestScotland2024()
+        {
+            var ukHols = new UKBankHoliday { UkCountry = UKBankHoliday.UkCountries.Scotland };
+            var hols = ukHols.PublicHolidayNames(2024);
+            Assert.AreEqual(9, hols.Count, "There are 9 holidays");
+            Assert.IsTrue(hols.ContainsKey(new DateTime(2024, 12, 02)), "St Andrew's Day");
+            foreach (var dateTime in hols.Keys)
+            {
+                Assert.IsTrue(ukHols.IsBankHoliday(dateTime), $"IsBankHoliday for {hols[dateTime]}");
+            }
+        }
 
         [TestMethod]
         public void TestScotland2025()
         {
             //according to https://www.mygov.scot/scotland-bank-holidays official dates:
             var ukHols = new UKBankHoliday { UkCountry = UKBankHoliday.UkCountries.Scotland };
-            var hols = ukHols.PublicHolidays(2025);
+            var hols = ukHols.PublicHolidayNames(2025);
             Assert.AreEqual(9, hols.Count, "There are 9 holidays");
+            Assert.IsTrue(hols.ContainsKey(new DateTime(2025, 12, 01)), "St Andrew's Day");
+            foreach (var dateTime in hols.Keys)
+            {
+                Assert.IsTrue(ukHols.IsBankHoliday(dateTime), $"IsBankHoliday for {hols[dateTime]}");
+            }
         }
 
         [TestMethod]


### PR DESCRIPTION
When St Andrews bank holiday in Scotland falls on a weekend e.g. 2024-11-30 and 2025-11-30 then this results in the bank holiday being in the following month i.e. December. This change handles the change of month.