### PR TITLE
Add support for Hungarian public holidays (HungaryPublicHoliday)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ There are libraries for:
   - France : FrancePublicHoliday
   - Germany : GermanPublicHoliday (set State property for regional holidays)
   - Greece : GreecePublicHoliday
+  - Hungary: HungaryPublicHoliday
   - Ireland : IrelandPublicHoliday
   - Italy : ItalyPublicHoliday
   - Lithuania : LithuaniaPublicHoliday

--- a/src/PublicHoliday/HungaryPublicHoliday.cs
+++ b/src/PublicHoliday/HungaryPublicHoliday.cs
@@ -1,0 +1,194 @@
+﻿using PublicHoliday;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PublicHoliday
+{
+    /// <summary>
+    /// Holidays in Hungary
+    /// Based on Hungarian Labor Code (Munka törvénykönyve)
+    /// </summary>
+    public class HungaryPublicHoliday : PublicHolidayBase
+    {
+        #region Individual Holidays
+
+        /// <summary>
+        /// Újév - New Year's Day
+        /// </summary>
+        /// <param name="year">The year.</param>
+        /// <returns>Date of in the given year.</returns>
+        public static DateTime NewYear(int year) => new DateTime(year, 1, 1);
+
+        /// <summary>
+        /// 1848-as forradalom ünnepe - National Day
+        /// Commemorates the Hungarian Revolution of 1848. 
+        /// It was reinstated as an official state holiday after the fall of communism.
+        /// </summary>
+        /// <param name="year">The year.</param>
+        /// <returns>Date of in the given year.</returns>
+        public static DateTime NationalDay1848(int year) => new DateTime(year, 3, 15);
+
+        /// <summary>
+        /// Nagypéntek - Good Friday
+        /// Introduced as a public holiday in Hungary since 2017
+        /// </summary>
+        /// <param name="year">The year.</param>
+        /// <returns>Date of in the given year.</returns>
+        public static DateTime GoodFriday(int year) => HolidayCalculator.GetEaster(year).AddDays(-2);
+
+        /// <summary>
+        /// Húsvéthétfő - Easter Monday
+        /// </summary>
+        /// <param name="year">The year.</param>
+        /// <returns>Date of in the given year.</returns>
+        public static DateTime EasterMonday(int year) => HolidayCalculator.GetEaster(year).AddDays(1);
+
+        /// <summary>
+        /// Munka ünnepe - International Workers' Day
+        /// Valid throughout the modern era.
+        /// </summary>
+        /// <param name="year">The year.</param>
+        /// <returns>Date of in the given year.</returns>
+        public static DateTime WorkersDay(int year) => new DateTime(year, 5, 1);
+
+        /// <summary>
+        /// Pünkösdhétfő - Pentecost Monday
+        /// Re-introduced as a public holiday after the political changes in the early 1990s.
+        /// </summary>
+        /// <param name="year">The year.</param>
+        /// <returns>Date of in the given year.</returns>
+        public static DateTime PentecostMonday(int year) => HolidayCalculator.GetEaster(year).AddDays(50);
+
+        /// <summary>
+        /// Államalapítás ünnepe - State Foundation Day
+        /// Commemorates Saint Stephen I, the first King of Hungary. 
+        /// During the communist era (1950-1989), it was celebrated as the Day of the Constitution or Day of the New Bread.
+        /// </summary>
+        /// <param name="year">The year.</param>
+        /// <returns>Date of in the given year.</returns>
+        public static DateTime SaintStephenDay(int year) => new DateTime(year, 8, 20);
+
+        /// <summary>
+        /// 1956-os forradalom ünnepe - National Day
+        /// Commemorates the Revolution of 1956 and the proclamation of the Republic of Hungary in 1989.
+        /// Official holiday since 1991.
+        /// </summary>
+        /// <param name="year">The year.</param>
+        /// <returns>Date of in the given year.</returns>
+        public static DateTime Revolution1956Day(int year) => new DateTime(year, 10, 23);
+
+        /// <summary>
+        /// Mindenszentek - All Saints' Day
+        /// Reinstated as a public holiday in 2000.
+        /// </summary>
+        /// <param name="year">The year.</param>
+        /// <returns>Date of in the given year.</returns>
+        public static DateTime AllSaints(int year) => new DateTime(year, 11, 1);
+
+        /// <summary>
+        /// Karácsony - Christmas Day
+        /// </summary>
+        /// <param name="year">The year.</param>
+        /// <returns>Date of in the given year.</returns>
+        public static DateTime ChristmasDay(int year) => new DateTime(year, 12, 25);
+
+        /// <summary>
+        /// Karácsony másnapja - Second Day of Christmas
+        /// </summary>
+        /// <param name="year">The year.</param>
+        /// <returns>Date of in the given year.</returns>
+        public static DateTime StStephenDay(int year) => new DateTime(year, 12, 26);
+
+        #endregion Individual Holidays
+
+        /// <summary>
+        /// Get a list of dates for all holidays in a year.
+        /// </summary>
+        /// <param name="year">The year</param>
+        /// <returns>List of public holidays</returns>
+        public override IList<DateTime> PublicHolidays(int year)
+        {
+            return PublicHolidayNames(year).Keys.OrderBy(x => x).ToList();
+        }
+
+        /// <summary>
+        /// Public holiday names in Hungarian.
+        /// </summary>
+        /// <param name="year">The year.</param>
+        /// <returns>Dictionary of holiday dates and names</returns>
+        public override IDictionary<DateTime, string> PublicHolidayNames(int year)
+        {
+            var dictionary = new Dictionary<DateTime, string>();
+
+            // Fixed dates
+            dictionary.Add(NewYear(year), "Újév");
+            dictionary.Add(NationalDay1848(year), "1848-as forradalom ünnepe");
+            dictionary.Add(WorkersDay(year), "Munka ünnepe");
+            dictionary.Add(SaintStephenDay(year), "Államalapítás ünnepe");
+            dictionary.Add(Revolution1956Day(year), "1956-os forradalom ünnepe");
+            dictionary.Add(AllSaints(year), "Mindenszentek");
+            dictionary.Add(ChristmasDay(year), "Karácsony");
+            dictionary.Add(StStephenDay(year), "Karácsony másnapja");
+
+            // Easter based holidays
+            DateTime easter = HolidayCalculator.GetEaster(year);
+            dictionary.Add(easter.AddDays(1), "Húsvéthétfő");
+            dictionary.Add(easter.AddDays(50), "Pünkösdhétfő");
+
+            // Good Friday was introduced as a public holiday in 2017
+            if (year >= 2017)
+            {
+                dictionary.Add(easter.AddDays(-2), "Nagypéntek");
+            }
+
+            return dictionary;
+        }
+
+        /// <summary>
+        /// Check if a specific date is a public holiday.
+        /// </summary>
+        /// <param name="dt">The date you wish to check</param>
+        /// <returns>True if date is a public holiday</returns>
+        public override bool IsPublicHoliday(DateTime dt)
+        {
+            int year = dt.Year;
+            DateTime date = dt.Date;
+
+            switch (dt.Month)
+            {
+                case 1:
+                    return NewYear(year) == date;
+                case 3:
+                    if (NationalDay1848(year) == date) return true;
+                    // Check Good Friday / Easter Monday if they fall in March
+                    if (year >= 2017 && GoodFriday(year) == date) return true;
+                    if (EasterMonday(year) == date) return true;
+                    break;
+                case 4:
+                    if (year >= 2017 && GoodFriday(year) == date) return true;
+                    if (EasterMonday(year) == date) return true;
+                    break;
+                case 5:
+                    if (WorkersDay(year) == date) return true;
+                    if (PentecostMonday(year) == date) return true;
+                    break;
+                case 6:
+                    if (PentecostMonday(year) == date) return true;
+                    break;
+                case 8:
+                    return SaintStephenDay(year) == date;
+                case 10:
+                    return Revolution1956Day(year) == date;
+                case 11:
+                    return AllSaints(year) == date;
+                case 12:
+                    if (ChristmasDay(year) == date) return true;
+                    if (StStephenDay(year) == date) return true;
+                    break;
+            }
+
+            return false;
+        }
+    }
+}

--- a/tests/PublicHolidayTests/TestHungaryPublicHoliday.cs
+++ b/tests/PublicHolidayTests/TestHungaryPublicHoliday.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PublicHoliday;
+
+namespace PublicHolidayTests
+{
+    /// <summary>
+    /// Test the Hungarian Bank Holidays
+    /// </summary>
+    [TestClass]
+    public class TestHungaryPublicHoliday
+    {
+        [TestMethod]
+        [DataRow(1, 1)]   // New Year
+        [DataRow(3, 15)]  // Revolution 1848
+        [DataRow(4, 14)]  // Good Friday 2017
+        [DataRow(4, 17)]  // Easter Monday 2017
+        [DataRow(5, 1)]   // Workers Day
+        [DataRow(6, 5)]   // Pentecost Monday 2017
+        [DataRow(8, 20)]  // St. Stephen
+        [DataRow(10, 23)] // Revolution 1956
+        [DataRow(11, 1)]  // All Saints
+        [DataRow(12, 25)] // Xmas 1
+        [DataRow(12, 26)] // Xmas 2
+        public void TestHuHolidays2017(int month, int day)
+        {
+            var holiday = new DateTime(2017, month, day);
+            var holidayCalendar = new HungaryPublicHoliday();
+            var actual = holidayCalendar.IsPublicHoliday(holiday);
+            Assert.IsTrue(actual, $"{holiday.ToString("D")} is not a holiday");
+        }
+
+        [TestMethod]
+        [DataRow(1, 6)]   // Epiphany (Holiday in SK, not in HU)
+        [DataRow(5, 8)]   // Victory Day (Holiday in CZ, not in HU)
+        [DataRow(11, 17)] // Velvet Revolution (Holiday in CZ, not in HU)
+        [DataRow(12, 24)] // Christmas Eve (Holiday in CZ, not in HU)
+        public void TestHuNoHolidays2017(int month, int day)
+        {
+            var holiday = new DateTime(2017, month, day);
+            var holidayCalendar = new HungaryPublicHoliday();
+            var actual = holidayCalendar.IsPublicHoliday(holiday);
+            Assert.IsFalse(actual, $"{holiday.ToString("D")} is a holiday (shouldn't be)");
+        }
+
+        /// <summary>
+        /// Test that Good Friday was NOT a holiday in 2016
+        /// </summary>
+        [TestMethod]
+        public void TestHuGoodFridayBefore2017()
+        {
+            var calendar = new HungaryPublicHoliday();
+
+            // In 2016, Good Friday was March 25th
+            var goodFriday2016 = new DateTime(2016, 3, 25);
+            Assert.IsFalse(calendar.IsPublicHoliday(goodFriday2016), "Good Friday should not be a holiday before 2017");
+
+            // In 2017, it should be a holiday
+            var goodFriday2017 = new DateTime(2017, 4, 14);
+            Assert.IsTrue(calendar.IsPublicHoliday(goodFriday2017), "Good Friday should be a holiday from 2017 onwards");
+        }
+
+        [TestMethod]
+        public void TestHuEasterMonday()
+        {
+            var calendar = new HungaryPublicHoliday();
+
+            // 2017
+            Assert.AreEqual(new DateTime(2017, 4, 17), HungaryPublicHoliday.EasterMonday(2017));
+            // 2026
+            Assert.AreEqual(new DateTime(2026, 4, 6), HungaryPublicHoliday.EasterMonday(2026));
+        }
+
+        [TestMethod]
+        public void TestHuPentecostMonday()
+        {
+            var calendar = new HungaryPublicHoliday();
+
+            // 2017 (Easter Sunday + 50 days)
+            Assert.AreEqual(new DateTime(2017, 6, 5), HungaryPublicHoliday.PentecostMonday(2017));
+            // 2026
+            Assert.AreEqual(new DateTime(2026, 5, 25), HungaryPublicHoliday.PentecostMonday(2026));
+        }
+
+        [TestMethod]
+        public void TestHuNextWorkingDayEaster2017()
+        {
+            var calendar = new HungaryPublicHoliday();
+            // Friday 14th April is holiday (Good Friday)
+            // Sat 15th, Sun 16th, Mon 17th (Easter Monday)
+            // Next working day should be Tuesday 18th April
+            var expected = new DateTime(2017, 4, 18);
+            var actual = calendar.NextWorkingDay(new DateTime(2017, 4, 14));
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void TestHuPreviousWorkingDay()
+        {
+            var calendar = new HungaryPublicHoliday();
+
+            // 1st Jan 2017 is Sunday (Holiday)
+            // Previous working day should be Friday 30th Dec 2016
+            var actual = calendar.PreviousWorkingDay(new DateTime(2017, 1, 1));
+            Assert.AreEqual(new DateTime(2016, 12, 30), actual);
+        }
+    }
+}


### PR DESCRIPTION
# Add support for Hungarian public holidays (HungaryPublicHoliday)

## Summary
This PR introduces a new holiday provider for **Hungary** (`HungaryPublicHoliday`). Currently, the library lacks support for Hungarian official public holidays, and this implementation fills that gap following the existing architectural patterns of the library.

## Key Features
- **Full Compliance**: Implements `PublicHolidayBase` and follows the naming conventions used in other European providers.
- **Historical Accuracy**: 
    - Includes **Good Friday** (Nagypéntek) as a public holiday only from **2017** onwards, consistent with Hungarian labor law changes.
    - Covers all major fixed and movable holidays (Easter, Pentecost).
- **Native Naming**: `PublicHolidayNames` returns official Hungarian names (e.g., *Újév*, *Nagypéntek*, *Húsvéthétfő*).
- **Optimized Performance**: The `IsPublicHoliday` method uses an optimized `switch` on months for $O(1)$ lookups, similar to the `CzechRepublicPublicHoliday` implementation.

## Implemented Holidays
| Date | Hungarian Name | English Name |
| :--- | :--- | :--- |
| **Jan 1** | Újév | New Year's Day |
| **Mar 15** | 1848-as forradalom ünnepe | 1848 Revolution Memorial Day |
| **Easter -2** | Nagypéntek | Good Friday (since 2017) |
| **Easter +1** | Húsvéthétfő | Easter Monday |
| **May 1** | Munka ünnepe | Labour Day |
| **Easter +50** | Pünkösdhétfő | Pentecost Monday |
| **Aug 20** | Államalapítás ünnepe | State Foundation Day (St. Stephen's Day) |
| **Oct 23** | 1956-os forradalom ünnepe | 1956 Revolution Memorial Day |
| **Nov 1** | Mindenszentek | All Saints' Day |
| **Dec 25** | Karácsony | Christmas Day |
| **Dec 26** | Karácsony másnapja | Second Day of Christmas |

## Tests
- Added comprehensive unit tests in `TestHungaryPublicHoliday.cs`.
- Verified movable dates for years **2017** and **2026**.
- Verified the **2017** historical threshold for Good Friday (ensuring it is not returned for 2016).