### PR TITLE
fix(switzerland): correct Geneva PrayDay to Thursday after first Sunday

### DIFF
--- a/src/PublicHoliday/SwitzerlandPublicHoliday.cs
+++ b/src/PublicHoliday/SwitzerlandPublicHoliday.cs
@@ -900,7 +900,7 @@ namespace PublicHoliday
         public static DateTime GenevaPrayDay(int year)
         {
             var firstSundayOfSeptember = HolidayCalculator.FindOccurrenceOfDayOfWeek(new DateTime(year, 9, 1), DayOfWeek.Sunday, 1);
-            return HolidayCalculator.FindPrevious(firstSundayOfSeptember, DayOfWeek.Thursday);
+            return HolidayCalculator.FindNext(firstSundayOfSeptember, DayOfWeek.Thursday);
         }
 
         private Holiday GenevaPrayDayHoliday(int year)

--- a/tests/PublicHolidayTests/TestSwitzerlandPublicHoliday.cs
+++ b/tests/PublicHolidayTests/TestSwitzerlandPublicHoliday.cs
@@ -307,7 +307,7 @@ namespace PublicHolidayTests
             IList<Holiday> hols = holidayCalendar.PublicHolidaysInformation(2024);
 
             Assert.IsTrue(hols[13].IsPublic == false);
-            Assert.IsTrue(hols[13].HolidayDate == new DateTime(2024, 8, 29));
+            Assert.IsTrue(hols[13].HolidayDate == new DateTime(2024, 9, 5));
             Assert.IsTrue(hols[13].Regions.Length == 1);
         }
 
@@ -364,6 +364,19 @@ namespace PublicHolidayTests
                 var hols = calendar.PublicHolidays(i);
                 Assert.IsTrue(4 == hols.Count);
             }
+        }
+
+        [TestMethod]
+        [DataRow(2024, 9, 5)]
+        [DataRow(2025, 9, 11)]
+        [DataRow(2026, 9, 10)]
+        [DataRow(2027, 9, 9)]
+        public void TestGenevaPrayDayIsThursdayAfterFirstSundayInSeptember(int year, int month, int day)
+        {
+            var result = SwitzerlandPublicHoliday.GenevaPrayDay(year);
+
+            Assert.AreEqual(new DateTime(year, month, day), result, "Geneva PrayDay is the Thursday after the first Sunday in September");
+            Assert.AreEqual(DayOfWeek.Thursday, result.DayOfWeek);
         }
     }
 }


### PR DESCRIPTION
## Problem

`SwitzerlandPublicHoliday.GenevaPrayDay(year)` is documented as *"Thursday after First Sunday in September"*, but it computes `FindPrevious(firstSundayOfSeptember, DayOfWeek.Thursday)`, which returns the Thursday **before** the first Sunday. The returned date is therefore one week too early every year.

| Year | Returned (before) | Correct (official) |
|------|-------------------|--------------------|
| 2024 | 29 Aug | 5 Sep |
| 2025 | 4 Sep  | 11 Sep |
| 2026 | 3 Sep  | 10 Sep |
| 2027 | 2 Sep  | 9 Sep |

The existing test `TestPublicHolidaysInformationGenevaPrayDay2024` had encoded the wrong date (29 Aug 2024), so the regression went unnoticed.

## Fix

- Use `FindNext` instead of `FindPrevious`, so the computed date matches the documented rule (Thursday after the first Sunday of September) and the official cantonal date.
- Correct the 2024 expectation in `TestSwitzerlandPublicHoliday`.
- Add a data-driven regression test covering 2024-2027 that also asserts the result is a Thursday.

## Verification

`dotnet test -f net10.0 --filter FullyQualifiedName~TestSwitzerlandPublicHoliday` -> **40 passed, 0 failed**.
