### PR TITLE
fix(switzerland): name Neuchâtel Republic Day correctly

### DIFF
--- a/src/PublicHoliday/SwitzerlandPublicHoliday.cs
+++ b/src/PublicHoliday/SwitzerlandPublicHoliday.cs
@@ -361,7 +361,7 @@ namespace PublicHoliday
                 }
             }
 
-            return new Holiday(holiday, "Republic Day", "Bundesfeier", cantonsName.ToArray());
+            return new Holiday(holiday, "Republic Day", "Instauration de la République", cantonsName.ToArray());
         }
 
         private readonly Cantons[] CantonsWithRepublicDay = new[] {

--- a/tests/PublicHolidayTests/TestSwitzerlandPublicHoliday.cs
+++ b/tests/PublicHolidayTests/TestSwitzerlandPublicHoliday.cs
@@ -365,5 +365,26 @@ namespace PublicHolidayTests
                 Assert.IsTrue(4 == hols.Count);
             }
         }
+
+        [TestMethod]
+        public void TestNeuchatelRepublicDayNameIsNotNationalDay()
+        {
+            var holidayCalendar = new SwitzerlandPublicHoliday { Canton = SwitzerlandPublicHoliday.Cantons.NE };
+            IList<Holiday> hols = holidayCalendar.PublicHolidaysInformation(2026);
+
+            Holiday republicDay = null;
+            foreach (var h in hols)
+            {
+                if (h.HolidayDate == new DateTime(2026, 3, 1))
+                {
+                    republicDay = h;
+                    break;
+                }
+            }
+
+            Assert.IsNotNull(republicDay, "Neuchâtel observes Republic Day on 1 March");
+            Assert.AreEqual("Republic Day", republicDay.EnglishName);
+            Assert.AreEqual("Instauration de la République", republicDay.Name);
+        }
     }
 }


### PR DESCRIPTION
## Problem

`SwitzerlandPublicHoliday` reports the Neuchâtel **Republic Day** (1 March) with the local name **"Bundesfeier"**, which is the **National Day** (1 August) label. `RepublicDayHoliday` passes `"Bundesfeier"` as the `localName` argument (a copy of `NationalDayHoliday`), and `Holiday.Name` returns the local name, so the two distinct holidays both surface as "Bundesfeier".

```csharp
// before
return new Holiday(holiday, "Republic Day", "Bundesfeier", cantonsName.ToArray());
```

## Fix

- Use `"Instauration de la République"` as the local name for Republic Day. Neuchâtel is a French-speaking canton, matching the French local name already used for Geneva PrayDay (`"Jeûne genevois"`). The English name (`"Republic Day"`) is unchanged.
- Add a regression test asserting the Neuchâtel 1 March holiday's English and local names.

## Verification

`dotnet test -f net10.0 --filter FullyQualifiedName~TestSwitzerlandPublicHoliday` -> **37 passed, 0 failed**.
