### PR TITLE
feat(localization): culture-aware CH/FR holiday names (en/fr/de/it)

### DIFF
--- a/src/PublicHoliday/FrancePublicHoliday.cs
+++ b/src/PublicHoliday/FrancePublicHoliday.cs
@@ -1134,7 +1134,42 @@ namespace PublicHoliday
         /// <returns></returns>
         public override IList<Holiday> PublicHolidaysInformation(int year)
         {
-            return PublicHolidayNames(year).Select(kvp => new Holiday(kvp.Key, kvp.Value)).ToList();
+            return PublicHolidayNames(year)
+                .Select(kvp =>
+                {
+                    var holiday = new Holiday(kvp.Key, kvp.Value);
+                    if (LocalizationIdsByName.TryGetValue(kvp.Value, out var idTextLocalization))
+                    {
+                        holiday.IdTextLocalization = idTextLocalization;
+                    }
+                    return holiday;
+                })
+                .ToList();
         }
+
+        /// <summary>
+        /// Maps each métropole / Alsace-Moselle holiday to its localization id, keyed by the French
+        /// name produced by <see cref="PublicHolidayNames"/>, so
+        /// <see cref="Holiday.GetName(System.Globalization.CultureInfo)"/> resolves culture-aware names.
+        /// Keyed by name rather than date: a movable feast that shares a calendar date with a fixed
+        /// holiday (e.g. Ascension landing on 1 or 8 May) is still identified correctly, which a
+        /// date-keyed lookup could not do. Overseas (DOM-TOM) holidays are intentionally not localized.
+        /// </summary>
+        private static readonly Dictionary<string, string> LocalizationIdsByName = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            { "Nouvel An", "NewYear" },
+            { "Vendredi saint", "GoodFriday" },
+            { "Lundi de Pâques", "EasterMonday" },
+            { "Fête du Travail", "LabourDay" },
+            { "Fête de la Victoire", "VictoryInEuropeDay" },
+            { "Jeudi de l'Ascension", "Ascension" },
+            { "Lundi de Pentecôte", "PentecostMonday" },
+            { "Fête nationale", "BastilleDay" },
+            { "Assomption", "Assumption" },
+            { "Toussaint", "AllSaints" },
+            { "Jour de l'armistice", "Armistice" },
+            { "Noël", "Christmas" },
+            { "Saint-Étienne", "SaintStephensDay" },
+        };
     }
 }

--- a/src/PublicHoliday/Localization/LocalizationString.xml
+++ b/src/PublicHoliday/Localization/LocalizationString.xml
@@ -32,6 +32,17 @@
     <Assumption value="Assumption"/>
     <AllSaints value="All Saints' Day"/>
     <Armistice value="Armistice Day"/>
+    <Berchtold value="Berchtold's Day"/>
+    <Epiphany value="Epiphany"/>
+    <NeuchatelRepublicDay value="Republic Day"/>
+    <StJoseph value="Saint Joseph's Day"/>
+    <SwissAscension value="Ascension Day"/>
+    <CorpusChristi value="Corpus Christi"/>
+    <SwissNationalDay value="Swiss National Day"/>
+    <GenevaPrayDay value="Geneva Fast"/>
+    <ImmaculateConception value="Immaculate Conception"/>
+    <SaintStephensDay value="St Stephen's Day"/>
+    <BastilleDay value="Bastille Day"/>
   </en>
   <fr>
     <NewYear value="Jour de l'An"/>
@@ -65,5 +76,64 @@
     <Assumption value="Assomption"/>
     <AllSaints value="Toussaint"/>
     <Armistice value="Jour de l'armistice"/>
+    <Berchtold value="Saint-Berchtold"/>
+    <Epiphany value="Épiphanie"/>
+    <NeuchatelRepublicDay value="Instauration de la République"/>
+    <StJoseph value="Saint-Joseph"/>
+    <SwissAscension value="Ascension"/>
+    <CorpusChristi value="Fête-Dieu"/>
+    <SwissNationalDay value="Fête nationale suisse"/>
+    <GenevaPrayDay value="Jeûne genevois"/>
+    <ImmaculateConception value="Immaculée Conception"/>
+    <SaintStephensDay value="Saint-Étienne"/>
+    <BastilleDay value="Fête nationale"/>
   </fr>
+  <de>
+    <NewYear value="Neujahrstag"/>
+    <Berchtold value="Berchtoldstag"/>
+    <Epiphany value="Heilige Drei Könige"/>
+    <NeuchatelRepublicDay value="Ausrufung der Republik"/>
+    <StJoseph value="Josefstag"/>
+    <GoodFriday value="Karfreitag"/>
+    <EasterMonday value="Ostermontag"/>
+    <LabourDay value="Tag der Arbeit"/>
+    <SwissAscension value="Auffahrt"/>
+    <Ascension value="Christi Himmelfahrt"/>
+    <PentecostMonday value="Pfingstmontag"/>
+    <CorpusChristi value="Fronleichnam"/>
+    <SwissNationalDay value="Bundesfeier"/>
+    <Assumption value="Mariä Himmelfahrt"/>
+    <GenevaPrayDay value="Genfer Bettag"/>
+    <AllSaints value="Allerheiligen"/>
+    <ImmaculateConception value="Mariä Empfängnis"/>
+    <Christmas value="Weihnachten"/>
+    <SaintStephensDay value="Stephanstag"/>
+    <VictoryInEuropeDay value="Tag des Sieges"/>
+    <BastilleDay value="Französischer Nationalfeiertag"/>
+    <Armistice value="Waffenstillstandstag"/>
+  </de>
+  <it>
+    <NewYear value="Capodanno"/>
+    <Berchtold value="San Berchtoldo"/>
+    <Epiphany value="Epifania"/>
+    <NeuchatelRepublicDay value="Instaurazione della Repubblica"/>
+    <StJoseph value="San Giuseppe"/>
+    <GoodFriday value="Venerdì Santo"/>
+    <EasterMonday value="Lunedì dell'Angelo"/>
+    <LabourDay value="Festa del lavoro"/>
+    <SwissAscension value="Ascensione"/>
+    <Ascension value="Ascensione"/>
+    <PentecostMonday value="Lunedì di Pentecoste"/>
+    <CorpusChristi value="Corpus Domini"/>
+    <SwissNationalDay value="Festa nazionale svizzera"/>
+    <Assumption value="Assunzione"/>
+    <GenevaPrayDay value="Digiuno ginevrino"/>
+    <AllSaints value="Ognissanti"/>
+    <ImmaculateConception value="Immacolata Concezione"/>
+    <Christmas value="Natale"/>
+    <SaintStephensDay value="Santo Stefano"/>
+    <VictoryInEuropeDay value="Festa della Vittoria"/>
+    <BastilleDay value="Festa nazionale francese"/>
+    <Armistice value="Armistizio"/>
+  </it>
 </root>

--- a/src/PublicHoliday/SwitzerlandPublicHoliday.cs
+++ b/src/PublicHoliday/SwitzerlandPublicHoliday.cs
@@ -223,7 +223,7 @@ namespace PublicHoliday
         private static Holiday NewYearHoliday(int year)
         {
             DateTime holiday = NewYear(year);
-            return new Holiday(holiday, "New Year", "Neujahrstag");
+            return new Holiday(holiday, "New Year", "Neujahrstag") { IdTextLocalization = "NewYear" };
         }
 
         #endregion 
@@ -255,7 +255,7 @@ namespace PublicHoliday
                 }
             }
             
-            return new Holiday(holiday, "Berchtold's Day", "Berchtoldstag", cantonsName.ToArray());
+            return new Holiday(holiday, "Berchtold's Day", "Berchtoldstag", cantonsName.ToArray()) { IdTextLocalization = "Berchtold" };
         }
 
         private readonly Cantons[] CantonsWithSecondJanuary = new[] {
@@ -312,7 +312,7 @@ namespace PublicHoliday
                 }
             }
 
-            return new Holiday(holiday, "Epiphany", "Epiphanie", cantonsName.ToArray());
+            return new Holiday(holiday, "Epiphany", "Epiphanie", cantonsName.ToArray()) { IdTextLocalization = "Epiphany" };
         }
 
         private readonly Cantons[] CantonsWithEpiphany = new[] {
@@ -361,7 +361,7 @@ namespace PublicHoliday
                 }
             }
 
-            return new Holiday(holiday, "Republic Day", "Bundesfeier", cantonsName.ToArray());
+            return new Holiday(holiday, "Republic Day", "Bundesfeier", cantonsName.ToArray()) { IdTextLocalization = "NeuchatelRepublicDay" };
         }
 
         private readonly Cantons[] CantonsWithRepublicDay = new[] {
@@ -407,7 +407,7 @@ namespace PublicHoliday
                 }
             }
 
-            return new Holiday(holiday, "Saint Joseph's Day", "Josefstag", cantonsName.ToArray());
+            return new Holiday(holiday, "Saint Joseph's Day", "Josefstag", cantonsName.ToArray()) { IdTextLocalization = "StJoseph" };
         }
 
         private readonly Cantons[] CantonsWithStJosephDay = new[] {
@@ -466,7 +466,7 @@ namespace PublicHoliday
                 }
             }
 
-            return new Holiday(holiday, "Good Friday", "Karfreitag", cantonsName.ToArray());
+            return new Holiday(holiday, "Good Friday", "Karfreitag", cantonsName.ToArray()) { IdTextLocalization = "GoodFriday" };
         }
 
         private readonly Cantons[] CantonsWithGoodFriday = new[] {
@@ -542,7 +542,7 @@ namespace PublicHoliday
                 }
             }
 
-            return new Holiday(holiday, "Easter Monday", "Ostermontag", cantonsName.ToArray());
+            return new Holiday(holiday, "Easter Monday", "Ostermontag", cantonsName.ToArray()) { IdTextLocalization = "EasterMonday" };
         }
 
         private readonly Cantons[] CantonsWithEasterMonday = new[] {
@@ -612,7 +612,7 @@ namespace PublicHoliday
                 }
             }
 
-            return new Holiday(holiday, "Labour Day", "Tag der Arbeit", cantonsName.ToArray());
+            return new Holiday(holiday, "Labour Day", "Tag der Arbeit", cantonsName.ToArray()) { IdTextLocalization = "LabourDay" };
         }
 
         private readonly Cantons[] CantonsWithLabourDay = new[] {
@@ -662,7 +662,7 @@ namespace PublicHoliday
         private static Holiday AscensionHoliday(DateTime easter)
         {
             DateTime holiday = Ascension(easter);
-            return new Holiday(holiday, "Ascension Day", "Auffahrt");
+            return new Holiday(holiday, "Ascension Day", "Auffahrt") { IdTextLocalization = "SwissAscension" };
         }
 
         #endregion
@@ -702,7 +702,7 @@ namespace PublicHoliday
                 }
             }
 
-            return new Holiday(holiday, "Whit Monday", "Pfingstmontag", cantonsName.ToArray());
+            return new Holiday(holiday, "Whit Monday", "Pfingstmontag", cantonsName.ToArray()) { IdTextLocalization = "PentecostMonday" };
         }
 
         private readonly Cantons[] CantonsWithWhitMonday = new[] {
@@ -784,7 +784,7 @@ namespace PublicHoliday
                 }
             }
 
-            return new Holiday(holiday, "Corpus Christi", "Fronleichnam", cantonsName.ToArray());
+            return new Holiday(holiday, "Corpus Christi", "Fronleichnam", cantonsName.ToArray()) { IdTextLocalization = "CorpusChristi" };
         }
 
         private readonly Cantons[] CantonsWithCorpusChristi = new[] {
@@ -829,7 +829,7 @@ namespace PublicHoliday
         private static Holiday NationalDayHoliday(int year)
         {
             DateTime holiday = NationalDay(year);
-            return new Holiday(holiday, "National Day", "Bundesfeier");
+            return new Holiday(holiday, "National Day", "Bundesfeier") { IdTextLocalization = "SwissNationalDay" };
         }
 
         #endregion
@@ -861,7 +861,7 @@ namespace PublicHoliday
                 }
             }
 
-            return new Holiday(holiday, "Assumption Day", "Mariä Himmelfahrt", cantonsName.ToArray());
+            return new Holiday(holiday, "Assumption Day", "Mariä Himmelfahrt", cantonsName.ToArray()) { IdTextLocalization = "Assumption" };
         }
 
         private readonly Cantons[] CantonsWithAssumption = new[] {
@@ -919,7 +919,7 @@ namespace PublicHoliday
                 }
             }
 
-            return new Holiday(holiday, "Geneva PrayDay", "Jeûne genevois", cantonsName.ToArray());
+            return new Holiday(holiday, "Geneva PrayDay", "Jeûne genevois", cantonsName.ToArray()) { IdTextLocalization = "GenevaPrayDay" };
         }
 
         private readonly Cantons[] CantonsWithGenevaPrayDay = new[] {
@@ -964,7 +964,7 @@ namespace PublicHoliday
                 }
             }
 
-            return new Holiday(holiday, "All Saints Day", "Allerheiligen", cantonsName.ToArray());
+            return new Holiday(holiday, "All Saints Day", "Allerheiligen", cantonsName.ToArray()) { IdTextLocalization = "AllSaints" };
         }
 
         private readonly Cantons[] CantonsWithAllSaints = new[] {
@@ -1023,7 +1023,7 @@ namespace PublicHoliday
                 }
             }
 
-            return new Holiday(holiday, "Immaculate Conception", "Unbefleckte Empfängnis", cantonsName.ToArray());
+            return new Holiday(holiday, "Immaculate Conception", "Unbefleckte Empfängnis", cantonsName.ToArray()) { IdTextLocalization = "ImmaculateConception" };
         }
 
         private readonly Cantons[] CantonsWithImmaculateConception = new[] {
@@ -1068,7 +1068,7 @@ namespace PublicHoliday
         private static Holiday ChristmasHoliday(int year)
         {
             DateTime holiday = Christmas(year);
-            return new Holiday(holiday, "Christmas Day", "Weihnachten");
+            return new Holiday(holiday, "Christmas Day", "Weihnachten") { IdTextLocalization = "Christmas" };
         }
 
         #endregion
@@ -1101,7 +1101,7 @@ namespace PublicHoliday
                 }
             }
 
-            return new Holiday(holiday, "St Stephen's Day", "Stephanstag", cantonsName.ToArray());
+            return new Holiday(holiday, "St Stephen's Day", "Stephanstag", cantonsName.ToArray()) { IdTextLocalization = "SaintStephensDay" };
         }
 
         private readonly Cantons[] CantonsWithSaintStephensDay = new[] {

--- a/tests/PublicHolidayTests/TestFrancePublicHoliday.cs
+++ b/tests/PublicHolidayTests/TestFrancePublicHoliday.cs
@@ -2,6 +2,8 @@
 using PublicHoliday;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
 
 namespace PublicHolidayTests
 {
@@ -160,6 +162,47 @@ namespace PublicHolidayTests
                 var hols = calendar.PublicHolidays(i);
                 Assert.AreEqual(11, hols.Count, "Should be 11 holidays");
             }
+        }
+
+        [TestMethod]
+        public void TestBastilleDayCultureAwareName()
+        {
+            var holidayCalendar = new FrancePublicHoliday { Region = FrancePublicHoliday.Regions.ALL };
+            IList<Holiday> hols = holidayCalendar.PublicHolidaysInformation(2026);
+
+            var bastilleDay = hols.Single(h => h.HolidayDate == new DateTime(2026, 7, 14));
+
+            Assert.AreEqual("Französischer Nationalfeiertag", bastilleDay.GetName(new CultureInfo("de")));
+            Assert.AreEqual("Festa nazionale francese", bastilleDay.GetName(new CultureInfo("it")));
+        }
+
+        [TestMethod]
+        public void TestAssumptionCultureAwareName()
+        {
+            var holidayCalendar = new FrancePublicHoliday { Region = FrancePublicHoliday.Regions.ALL };
+            IList<Holiday> hols = holidayCalendar.PublicHolidaysInformation(2026);
+
+            var assumption = hols.Single(h => h.HolidayDate == new DateTime(2026, 8, 15));
+
+            Assert.AreEqual("Mariä Himmelfahrt", assumption.GetName(new CultureInfo("de")));
+        }
+
+        [TestMethod]
+        public void TestAscensionCultureAwareNameWhenCollidingWithMayHoliday()
+        {
+            // In 2008 Ascension falls on 1 May, the same day as Fête du Travail. Each holiday must
+            // still resolve to its own culture-aware name. Regression guard: a date-keyed id lookup
+            // mislabeled the movable Ascension with the fixed holiday's id on collision years.
+            var holidayCalendar = new FrancePublicHoliday { Region = FrancePublicHoliday.Regions.ALL };
+            IList<Holiday> hols = holidayCalendar.PublicHolidaysInformation(2008);
+
+            var ascension = hols.Single(h => h.Name == "Jeudi de l'Ascension");
+            Assert.AreEqual(new DateTime(2008, 5, 1), ascension.HolidayDate.Date);
+            Assert.AreEqual("Christi Himmelfahrt", ascension.GetName(new CultureInfo("de")));
+            Assert.AreEqual("Ascensione", ascension.GetName(new CultureInfo("it")));
+
+            var labourDay = hols.Single(h => h.Name == "Fête du Travail");
+            Assert.AreEqual("Tag der Arbeit", labourDay.GetName(new CultureInfo("de")));
         }
     }
 }

--- a/tests/PublicHolidayTests/TestSwitzerlandPublicHoliday.cs
+++ b/tests/PublicHolidayTests/TestSwitzerlandPublicHoliday.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using PublicHoliday;
 
@@ -364,6 +366,41 @@ namespace PublicHolidayTests
                 var hols = calendar.PublicHolidays(i);
                 Assert.IsTrue(4 == hols.Count);
             }
+        }
+
+        [TestMethod]
+        public void TestGenevaPrayDayCultureAwareName()
+        {
+            var holidayCalendar = new SwitzerlandPublicHoliday
+            {
+                Canton = SwitzerlandPublicHoliday.Cantons.GE
+            };
+            IList<Holiday> hols = holidayCalendar.PublicHolidaysInformation(2026);
+
+            var genevaPrayDay = hols.SingleOrDefault(h => h.EnglishName == "Geneva PrayDay");
+            Assert.IsNotNull(genevaPrayDay, "Geneva PrayDay should be present for canton GE");
+
+            Assert.AreEqual("Genfer Bettag", genevaPrayDay.GetName(new CultureInfo("de")));
+            Assert.AreEqual("Jeûne genevois", genevaPrayDay.GetName(new CultureInfo("fr")));
+            Assert.AreEqual("Digiuno ginevrino", genevaPrayDay.GetName(new CultureInfo("it")));
+            Assert.AreEqual("Geneva Fast", genevaPrayDay.GetName(new CultureInfo("en")));
+        }
+
+        [TestMethod]
+        public void TestChristmasCultureAwareName()
+        {
+            var holidayCalendar = new SwitzerlandPublicHoliday
+            {
+                Canton = SwitzerlandPublicHoliday.Cantons.GE
+            };
+            IList<Holiday> hols = holidayCalendar.PublicHolidaysInformation(2026);
+
+            var christmas = hols.Single(h => h.HolidayDate == new DateTime(2026, 12, 25));
+
+            Assert.AreEqual("Weihnachten", christmas.GetName(new CultureInfo("de")));
+            Assert.AreEqual("Natale", christmas.GetName(new CultureInfo("it")));
+            Assert.AreEqual("Fête de Noël", christmas.GetName(new CultureInfo("fr")));
+            Assert.AreEqual("Christmas", christmas.GetName(new CultureInfo("en")));
         }
     }
 }


### PR DESCRIPTION
## What

Make Switzerland and France holidays support culture-aware names through the existing localization system (`Holiday.IdTextLocalization` + `LocalizationString.xml` + `Holiday.GetName(CultureInfo)`), in **English, French, German and Italian**.

Today `GetName(culture)` returns an empty string for Swiss and French holidays because those calendars only set `EnglishName` + a single hardcoded local name. After this change:

```csharp
var ch = new SwitzerlandPublicHoliday { Canton = SwitzerlandPublicHoliday.Cantons.GE };
var jg = ch.PublicHolidaysInformation(2026).Single(h => h.HolidayDate.Month == 9);
jg.GetName(new CultureInfo("de")); // "Genfer Bettag"
jg.GetName(new CultureInfo("fr")); // "Jeûne genevois"
jg.GetName(new CultureInfo("it")); // "Digiuno ginevrino"
```

## Design

- **Purely additive / non-breaking.** `EnglishName`, the local-name constructor argument and the `Holiday.Name` property are untouched, and no existing `<en>`/`<fr>` value is modified. Only the previously empty `GetName(culture)` starts resolving for CH/FR holidays.
- **XML.** Adds `<de>` and `<it>` language nodes and the missing keys under `<en>`/`<fr>`.
- **Switzerland.** Each holiday gets an `IdTextLocalization` via an object initializer. Swiss German intentionally keeps `Auffahrt` for Ascension (distinct key from the generic `Christi Himmelfahrt`).
- **France.** `PublicHolidaysInformation` reconstructs holidays from `PublicHolidayNames`, so ids are mapped by the French holiday name (not by date). This stays correct when a movable feast (Ascension) shares a date with a fixed holiday on 1 or 8 May. Overseas (DOM-TOM) holidays are intentionally left unlocalized (no established de/it names).

## Tests

MSTest coverage for en/fr/de/it resolution on Swiss and French holidays, including the Ascension/May date-collision year (2008).

## Verification

`dotnet test -f net10.0` -> **2048 passed, 0 failed, 1 skipped** (whole suite).
